### PR TITLE
Add Test for packetization and depacketization

### DIFF
--- a/test/depacketization/Makefile
+++ b/test/depacketization/Makefile
@@ -1,0 +1,33 @@
+APP_NAME = "depacketizationTest.bin"
+
+# Source Files
+SRCS += "depacketization_test.c"
+SRCS += "../../codec_packetizers/h264/h264_depacketizer.c"
+SRCS += "../../codec_packetizers/vp8/vp8_depacketizer.c"
+SRCS += "../../codec_packetizers/g711/g711_depacketizer.c"
+SRCS += "../../codec_packetizers/opus/opus_depacketizer.c"
+
+# Include Directories
+INCLUDE_DIRS += "-I../../codec_packetizers/h264/include/"
+INCLUDE_DIRS += "-I../../codec_packetizers/vp8/include/"
+INCLUDE_DIRS += "-I../../codec_packetizers/g711/include/"
+INCLUDE_DIRS += "-I../../codec_packetizers/opus/include/"
+
+OBJS=$(SRCS:.c=.o)
+
+CFLAGS+=-ggdb
+
+.DEFAULT_GOAL:=all
+
+all: build run
+
+build:
+	$(CC) -o $(APP_NAME) $(SRCS) $(INCLUDE_DIRS) $(CFLAGS)
+
+run:
+	./$(APP_NAME)
+
+clean:
+	rm -rf $(APP_NAME)
+
+.PHONY: all build run clean

--- a/test/depacketization/depacketization_test.c
+++ b/test/depacketization/depacketization_test.c
@@ -1,0 +1,544 @@
+/* Standard includes. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+/* API includes. */
+#include "h264_depacketizer.h"
+#include "vp8_depacketizer.h"
+#include "g711_depacketizer.h"
+#include "opus_depacketizer.h"
+
+#define MAX_PACKETS_IN_A_FRAME 512
+#define MAX_NALU_LENGTH   5 * 1024
+#define MAX_FRAME_LENGTH  10 * 1024
+#define MAX_PACKET_IN_A_FRAME 512
+
+#define VP8_PACKETS_ARR_LEN 10
+#define VP8_FRAME_BUF_LEN 32
+/*-----------------------------------------------------------*/
+
+void Depacketize_Nalus( void )
+{
+    int i;
+    H264Result_t result;
+    H264Packet_t pkt;
+    H264DepacketizerContext_t ctx;
+    Nalu_t nalu;
+    uint8_t naluBuffer[ MAX_NALU_LENGTH ];
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData1[] = {0x09, 0x10};
+    uint8_t packetData2[] = {0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xec, 0x05, 0xa8, 0x08 };
+    uint8_t packetData3[] = {0x68, 0xce, 0x3c, 0x80 };
+    uint8_t packetData4[] = {0x06, 0x05, 0xff, 0xff, 0xb7, 0xdc, 0x45, 0xe9, 0xbd, 0xe6, 0xd9, 0x48 };
+    uint8_t packetData5[] = {0x7c, 0x85, 0x88, 0x84, 0x12, 0xff, 0xff, 0xfc, 0x3d, 0x14, 0x0, 0x4 };
+    uint8_t packetData6[] = {0x7c, 0x45, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba };
+    uint8_t packetData7[] = {0x65, 0x00, 0x6e, 0x22, 0x21, 0x04, 0xbf, 0xff, 0xff, 0x0f, 0x45, 0x00};
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData1[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData1 );
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData2[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData2 );
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData3[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData3 );
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData4[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData4 );
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData5[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData5 );
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData6[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData6 );
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData7[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData7 );
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+    assert( result == H264_RESULT_OK );
+
+    while( result != H264_RESULT_NO_MORE_NALUS )
+    {
+        nalu.pNaluData = &( naluBuffer[ 0 ] );
+        nalu.naluDataLength = MAX_NALU_LENGTH;
+        result = H264Depacketizer_GetNalu( &( ctx ),
+                                           &( nalu ) );
+
+    }
+    assert( result == H264_RESULT_NO_MORE_NALUS );
+}
+
+/*-----------------------------------------------------------*/
+
+void Depacketize_Frames( void )
+{
+    H264Result_t result;
+    H264Packet_t pkt;
+    H264DepacketizerContext_t ctx;
+    Frame_t frame;
+    uint8_t frameBuffer[ MAX_FRAME_LENGTH ];
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData1[] = {0x09, 0x10};
+    uint8_t packetData2[] = {0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xec, 0x05, 0xa8, 0x08 };
+    uint8_t packetData3[] = {0x68, 0xce, 0x3c, 0x80 };
+    uint8_t packetData4[] = {0x06, 0x05, 0xff, 0xff, 0xb7, 0xdc, 0x45, 0xe9, 0xbd, 0xe6, 0xd9, 0x48 };
+    uint8_t packetData5[] = {0x7c, 0x85, 0x88, 0x84, 0x12, 0xff, 0xff, 0xfc, 0x3d, 0x14, 0x0, 0x4 };
+    uint8_t packetData6[] = {0x7c, 0x45, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba };
+    uint8_t packetData7[] = {0x65, 0x00, 0x6e, 0x22, 0x21, 0x04, 0xbf, 0xff, 0xff, 0x0f, 0x45, 0x00};
+    uint32_t totalSize = 0;
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData1[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData1 );
+    totalSize += pkt.packetDataLength;
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData2[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData2 );
+    totalSize += pkt.packetDataLength;
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData3[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData3 );
+    totalSize += pkt.packetDataLength;
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData4[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData4 );
+    totalSize += pkt.packetDataLength;
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData5[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData5 );
+    totalSize += pkt.packetDataLength;
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData6[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData6 );
+    totalSize += pkt.packetDataLength;
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( packetData7[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData7 );
+    totalSize += pkt.packetDataLength;
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == H264_RESULT_OK );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = MAX_FRAME_LENGTH;
+    result = H264Depacketizer_GetFrame( &( ctx ),
+                                        &( frame ) );
+    assert( result == H264_RESULT_OK );
+}
+
+/*-----------------------------------------------------------*/
+
+void GetPropertiesTest( void )
+{
+    uint8_t singleNaluPacket[] = { 0x09, 0x10 };
+    uint8_t fuAStartPacket[] = { 0x7C, 0x89, 0xAB, 0xCD };
+    uint8_t fuAEndPacket[] = { 0x7C, 0x49, 0xAB, 0xCD };
+    uint32_t packetProperties;
+    H264Result_t result;
+    H264Packet_t pkt;
+
+    pkt.pPacketData = &( singleNaluPacket[ 0 ] );
+    pkt.packetDataLength = sizeof( singleNaluPacket );
+    result = H264Depacketizer_GetPacketProperties( pkt.pPacketData,
+                                                   pkt.packetDataLength,
+                                                   &( packetProperties ) );
+    assert( result == H264_RESULT_OK );
+    assert( packetProperties == H264_PACKET_PROPERTY_START_PACKET );
+
+    pkt.pPacketData = &( fuAStartPacket[ 0 ] );
+    pkt.packetDataLength = sizeof( fuAStartPacket );
+    result = H264Depacketizer_GetPacketProperties( pkt.pPacketData,
+                                                   pkt.packetDataLength,
+                                                   &( packetProperties ) );
+    assert( result == H264_RESULT_OK );
+    assert( packetProperties == H264_PACKET_PROPERTY_START_PACKET );
+
+    pkt.pPacketData = &( fuAEndPacket[ 0 ] );
+    pkt.packetDataLength = sizeof( fuAEndPacket );
+    result = H264Depacketizer_GetPacketProperties( pkt.pPacketData,
+                                                   pkt.packetDataLength,
+                                                   &( packetProperties ) );
+    assert( result == H264_RESULT_OK );
+    assert( packetProperties == H264_PACKET_PROPERTY_END_PACKET );
+}
+
+/*-----------------------------------------------------------*/
+
+void Depacketize_VP8_Frames_1()
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Packet_t pkt;
+    VP8Frame_t frame;
+    VP8Packet_t packetsArray[ VP8_PACKETS_ARR_LEN ];
+    uint8_t frameBuffer[ VP8_FRAME_BUF_LEN ];
+    size_t i;
+
+    uint8_t packetData1[] = { 0xB0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA, 0x00, 0x01, 0x02, 0x03 };
+    uint8_t packetData2[] = { 0xA0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA, 0x04, 0x05, 0x10, 0x11 };
+    uint8_t packetData3[] = { 0xA0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA, 0x12, 0x13, 0x14, 0x15 };
+    uint8_t packetData4[] = { 0xA0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA, 0x20, 0x21, 0x22, 0x23 };
+    uint8_t packetData5[] = { 0xA0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA, 0x24, 0x25, 0x30, 0x31 };
+    uint8_t packetData6[] = { 0xA0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA, 0x32, 0x33, 0x34, 0x35 };
+    uint8_t packetData7[] = { 0xA0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA, 0x40, 0x41 };
+
+    uint8_t decodedFrameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                   0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                                   0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                                   0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                                   0x40, 0x41 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData1[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData1 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData2[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData2 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData3[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData3 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData4[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData4 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData5[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData5 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData6[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData6 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData7[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData7 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+    result = VP8Depacketizer_GetFrame( &( ctx ),
+                                       &( frame ) );
+    assert( result == VP8_RESULT_OK );
+
+    assert( frame.frameDataLength == sizeof( decodedFrameData ) );
+    for( i = 0; i < frame.frameDataLength; i++ )
+    {
+        assert( frame.pFrameData[ i ] == decodedFrameData[ i ] );
+    }
+    assert( frame.pictureId == 0x7ACD );
+    assert( frame.tl0PicIndex == 0xAB );
+    assert( frame.tid == 5 );
+    assert( frame.keyIndex == 10 );
+    assert( frame.frameProperties == ( VP8_FRAME_PROP_NON_REF_FRAME |
+                                       VP8_FRAME_PROP_PICTURE_ID_PRESENT |
+                                       VP8_FRAME_PROP_TL0PICIDX_PRESENT |
+                                       VP8_FRAME_PROP_TID_PRESENT |
+                                       VP8_FRAME_PROP_KEYIDX_PRESENT |
+                                       VP8_FRAME_PROP_DEPENDS_ON_BASE_ONLY ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void Depacketize_VP8_Frames_2()
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Packet_t pkt;
+    VP8Frame_t frame;
+    VP8Packet_t packetsArray[ VP8_PACKETS_ARR_LEN ];
+    uint8_t frameBuffer[ VP8_FRAME_BUF_LEN ];
+    size_t i;
+
+    uint8_t packetData1[] = { 0xB0, 0x40, 0xAB, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x10 };
+    uint8_t packetData2[] = { 0xA0, 0x40, 0xAB, 0x11, 0x12, 0x13, 0x14, 0x15, 0x20, 0x21 };
+    uint8_t packetData3[] = { 0xA0, 0x40, 0xAB, 0x22, 0x23, 0x24, 0x25, 0x30, 0x31, 0x32 };
+    uint8_t packetData4[] = { 0xA0, 0x40, 0xAB, 0x33, 0x34, 0x35, 0x40, 0x41 };
+
+    uint8_t decodedFrameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                   0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                                   0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                                   0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                                   0x40, 0x41 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData1[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData1 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData2[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData2 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData3[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData3 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( packetData4[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData4 );
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+    assert( result == VP8_RESULT_OK );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+    result = VP8Depacketizer_GetFrame( &( ctx ),
+                                       &( frame ) );
+    assert( result == VP8_RESULT_OK );
+
+    assert( frame.frameDataLength == sizeof( decodedFrameData ) );
+    for( i = 0; i < frame.frameDataLength; i++ )
+    {
+        assert( frame.pFrameData[ i ] == decodedFrameData[ i ] );
+    }
+    assert( frame.tl0PicIndex == 0xAB );
+    assert( frame.frameProperties == ( VP8_FRAME_PROP_NON_REF_FRAME |
+                                       VP8_FRAME_PROP_TL0PICIDX_PRESENT ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void Depacketize_G711_Frames()
+{
+    G711Result_t result;
+    G711DepacketizerContext_t ctx;
+    G711Packet_t packetsArray[ MAX_PACKET_IN_A_FRAME ], pkt;
+    G711Frame_t frame;
+    uint8_t frameBuffer[ MAX_FRAME_LENGTH ];
+    size_t i;
+
+    uint8_t packetData1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x10, 0x11, 0x12, 0x13};
+    uint8_t packetData2[] = {0x14, 0x15, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x30, 0x31};
+    uint8_t packetData3[] = {0x32, 0x33, 0x34, 0x35, 0x40, 0x41};
+
+    uint8_t decodedFrame[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                               0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                               0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                               0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                               0x40, 0x41 };
+
+    result = G711Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKET_IN_A_FRAME );
+    assert( result == G711_RESULT_OK );
+
+    pkt.pPacketData = &( packetData1[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData1 );
+    result = G711Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == G711_RESULT_OK );
+
+    pkt.pPacketData = &( packetData2[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData2 );
+    result = G711Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == G711_RESULT_OK );
+
+    pkt.pPacketData = &( packetData3[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData3 );
+    result = G711Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == G711_RESULT_OK );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = MAX_FRAME_LENGTH;
+    result = G711Depacketizer_GetFrame( &( ctx ),
+                                        &( frame ) );
+    assert( result == G711_RESULT_OK );
+    assert( frame.frameDataLength == sizeof( decodedFrame ) );
+    for( i = 0; i < frame.frameDataLength; i++ )
+    {
+        assert( frame.pFrameData[ i ] == decodedFrame[ i ] );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+void Depacketize_Opus_Frames()
+{
+    OpusResult_t result;
+    OpusDepacketizerContext_t ctx;
+    OpusPacket_t packetsArray[ MAX_PACKET_IN_A_FRAME ], pkt;
+    OpusFrame_t frame;
+    uint8_t frameBuffer[ MAX_FRAME_LENGTH ];
+    size_t i;
+
+    uint8_t packetData1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x10, 0x11, 0x12, 0x13};
+    uint8_t packetData2[] = {0x14, 0x15, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x30, 0x31};
+    uint8_t packetData3[] = {0x32, 0x33, 0x34, 0x35, 0x40, 0x41};
+
+    uint8_t decodedFrame[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                               0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                               0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                               0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                               0x40, 0x41 };
+
+    result = OpusDepacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKET_IN_A_FRAME );
+    assert( result == OPUS_RESULT_OK );
+
+    pkt.pPacketData = &( packetData1[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData1 );
+    result = OpusDepacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == OPUS_RESULT_OK );
+
+    pkt.pPacketData = &( packetData2[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData2 );
+    result = OpusDepacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == OPUS_RESULT_OK );
+
+    pkt.pPacketData = &( packetData3[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData3 );
+    result = OpusDepacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    assert( result == OPUS_RESULT_OK );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = MAX_FRAME_LENGTH;
+    result = OpusDepacketizer_GetFrame( &( ctx ),
+                                        &( frame ) );
+    assert( result == OPUS_RESULT_OK );
+    assert( frame.frameDataLength == sizeof( decodedFrame ) );
+    for( i = 0; i < frame.frameDataLength; i++ )
+    {
+        assert( frame.pFrameData[ i ] == decodedFrame[ i ] );
+    }
+}
+
+/*-----------------------------------------------------------*/
+void H264_test_case()
+{
+    printf( "\nRunning H264 Test Cases\n" );
+    Depacketize_Nalus();
+    printf( "\tTest 1 - H264 depacketize Nalus Test passed\n" );
+    Depacketize_Frames();
+    printf( "\tTest 2 - H264 depacketize Frames Test passed\n" );
+    GetPropertiesTest();
+    printf( "\tTest 3 - H264 Get Properties Passed\n" );
+
+}
+
+void VP8_test_case()
+{
+    printf( "\nRunning VP8 Test Cases\n" );
+    Depacketize_VP8_Frames_1();
+    printf( "\tTest 1 - VP8 depacketize Test passed\n" );
+    Depacketize_VP8_Frames_2();
+    printf( "\tTest 2 - VP8 depacketize Test passed\n" );
+}
+
+void G711_test_case()
+{
+    printf( "\nRunning G711 Test Cases\n" );
+    Depacketize_G711_Frames();
+    printf( "\tTest 1 - G711 depacketize Test passed\n" );
+}
+
+void Opus_test_case()
+{
+    printf( "\nRunning OPUS Test Cases\n" );
+    Depacketize_Opus_Frames();
+    printf( "\tTest 1 - Opus depacketize Test passed\n" );
+}
+
+int main( void )
+{
+    H264_test_case();
+
+    VP8_test_case();
+
+    G711_test_case();
+
+    Opus_test_case();
+
+    return 0;
+}
+
+/*-----------------------------------------------------------*/

--- a/test/packetization/Makefile
+++ b/test/packetization/Makefile
@@ -1,0 +1,33 @@
+APP_NAME = "packetizationTest.bin"
+
+# Source Files
+SRCS += "packetization_test.c"
+SRCS += "../../codec_packetizers/h264/h264_packetizer.c"
+SRCS += "../../codec_packetizers/g711/g711_packetizer.c"
+SRCS += "../../codec_packetizers/opus/opus_packetizer.c"
+SRCS += "../../codec_packetizers/vp8/vp8_packetizer.c"
+
+# Include Directories
+INCLUDE_DIRS += "-I../../codec_packetizers/h264/include/"
+INCLUDE_DIRS += "-I../../codec_packetizers/g711/include/"
+INCLUDE_DIRS += "-I../../codec_packetizers/opus/include/"
+INCLUDE_DIRS += "-I../../codec_packetizers/vp8/include/"
+
+OBJS=$(SRCS:.c=.o)
+
+CFLAGS+=-ggdb
+
+.DEFAULT_GOAL:=all
+
+all: build run
+
+build:
+	$(CC) -o $(APP_NAME) $(SRCS) $(INCLUDE_DIRS) $(CFLAGS)
+
+run:
+	./$(APP_NAME)
+
+clean:
+	rm -rf $(APP_NAME)
+
+.PHONY: all build run clean

--- a/test/packetization/packetization_test.c
+++ b/test/packetization/packetization_test.c
@@ -1,0 +1,841 @@
+/* Standard includes. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+/* API includes. */
+#include "h264_packetizer.h"
+#include "g711_packetizer.h"
+#include "vp8_packetizer.h"
+#include "opus_packetizer.h"
+
+#define MAX_NALUS_IN_A_FRAME 512
+#define MAX_PACKET_LENGTH   1200
+
+#define VP8_PACKET_LENGTH   10
+#define G711_PACKET_LENGTH  10
+#define OPUS_PACKET_LENGTH  10
+/*-----------------------------------------------------------*/
+
+void DumpPacket( H264Packet_t * pPacket,
+                 int packetNumber )
+{
+    size_t i;
+
+    printf( "Packet No %d - Packet Length: %lu.\r\n",
+            packetNumber,
+            pPacket->packetDataLength );
+    for( i = 0; i < pPacket->packetDataLength; i++ )
+    {
+        printf( "0x%02x, ",
+                pPacket->pPacketData[i] );
+    }
+    printf( "\n" );
+}
+
+void DumpNalu( uint8_t * pNalu,
+               int naluLength,
+               int naluNumber )
+{
+    size_t i;
+
+    printf( "Nalu No %d - Nalu Length: %u.\r\n",
+            naluNumber,
+            naluLength );
+    for( i = 0; i < naluLength; i++ )
+    {
+        printf( "0x%02x, ",
+                pNalu[i] );
+    }
+    printf( "\n" );
+}
+
+/*-----------------------------------------------------------*/
+
+void ProcessNalu( H264PacketizerContext_t * pCtx,
+                  int naluNumber,
+                  uint8_t * pNalu,
+                  size_t naluLength )
+{
+    Nalu_t nalu;
+    H264Result_t result;
+
+    nalu.pNaluData = pNalu;
+    nalu.naluDataLength = naluLength;
+
+    result = H264Packetizer_AddNalu( pCtx,
+                                     &( nalu ) );
+    assert( result == H264_RESULT_OK );
+}
+
+/*-----------------------------------------------------------*/
+
+void ProcessFrame( uint8_t * pFrame,
+                   size_t frameLength )
+{
+    int naluNumber = 0, packetNumber = 0;
+    size_t curIndex = 0, naluStartIndex = 0, remainingLength;
+    uint32_t fistStartCode = 1;
+    H264PacketizerContext_t ctx;
+    H264Result_t result;
+    H264Packet_t pkt;
+    uint8_t pktBuffer[ MAX_PACKET_LENGTH ];
+    Nalu_t nalusArray[ MAX_NALUS_IN_A_FRAME ];
+    uint32_t mtuSize = 12, i = 0;
+    uint32_t expectedPacketLength[] = { 2, 12, 4, 12, 12, 12, 12 };
+
+    uint8_t startCode1[] = { 0x00, 0x00, 0x00, 0x01 };
+    uint8_t startCode2[] = { 0x00, 0x00, 0x01 };
+
+    result = H264Packetizer_Init( &( ctx ),
+                                  &( nalusArray[ 0 ] ),
+                                  MAX_NALUS_IN_A_FRAME );
+    assert( result == H264_RESULT_OK );
+
+    while( curIndex < frameLength )
+    {
+        remainingLength = frameLength - curIndex;
+
+        /* Check the presence of 4 byte start code. */
+        if( remainingLength >= sizeof( startCode1 ) )
+        {
+            if( memcmp( &( pFrame[ curIndex ] ),
+                        &( startCode1[ 0 ] ),
+                        sizeof( startCode1 ) ) == 0 )
+            {
+                if( fistStartCode == 1 )
+                {
+                    fistStartCode = 0;
+                }
+                else
+                {
+                    naluNumber++;
+                    ProcessNalu( &( ctx ),
+                                 naluNumber,
+                                 &( pFrame[ naluStartIndex ] ),
+                                 curIndex - naluStartIndex );
+                }
+
+                naluStartIndex = curIndex + sizeof( startCode1 );
+                curIndex = curIndex + sizeof( startCode1 );
+                continue;
+            }
+        }
+
+        /* Check the presence of 3 byte start code. */
+        if( remainingLength >= sizeof( startCode2 ) )
+        {
+            if( memcmp( &( pFrame[ curIndex ] ),
+                        &( startCode2[ 0 ] ),
+                        sizeof( startCode2 ) ) == 0 )
+            {
+                if( fistStartCode == 1 )
+                {
+                    fistStartCode = 0;
+                }
+                else
+                {
+                    naluNumber++;
+                    ProcessNalu( &( ctx ),
+                                 naluNumber,
+                                 &( pFrame[ naluStartIndex ] ),
+                                 curIndex - naluStartIndex );
+                }
+
+                naluStartIndex = curIndex + sizeof( startCode2 );
+                curIndex = curIndex + sizeof( startCode2 );
+                continue;
+            }
+        }
+
+        curIndex += 1;
+    }
+
+    if( naluStartIndex > 0 )
+    {
+        naluNumber++;
+        ProcessNalu( &( ctx ),
+                     naluNumber,
+                     &( pFrame[ naluStartIndex ] ),
+                     frameLength - naluStartIndex );
+    }
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = mtuSize;
+    result = H264Packetizer_GetPacket( &( ctx ),
+                                       &( pkt ) );
+
+
+    while( result != H264_RESULT_NO_MORE_PACKETS )
+    {
+        packetNumber++;
+        assert( expectedPacketLength[i++] == pkt.packetDataLength );
+        //DumpPacket( &( pkt ), packetNumber );
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = mtuSize;
+        result = H264Packetizer_GetPacket( &( ctx ),
+                                           &( pkt ) );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+void ProcessFrame2( uint8_t * pFrame,
+                    size_t frameLength )
+{
+    int packetNumber = 0;
+    H264PacketizerContext_t ctx;
+    H264Result_t result;
+    H264Packet_t pkt;
+    Frame_t frame;
+    Nalu_t nalusArray[ MAX_NALUS_IN_A_FRAME ];
+    uint8_t pktBuffer[ MAX_PACKET_LENGTH ];
+    uint32_t mtuSize = 12,i = 0;
+    uint32_t expectedPacketLength[] = { 2, 12, 4, 12, 12, 12, 12 };
+
+    result = H264Packetizer_Init( &( ctx ),
+                                  &( nalusArray[ 0 ] ),
+                                  MAX_NALUS_IN_A_FRAME );
+    assert( result == H264_RESULT_OK );
+
+    frame.pFrameData = pFrame;
+    frame.frameDataLength = frameLength;
+    result = H264Packetizer_AddFrame( &( ctx ),
+                                      &( frame ) );
+    assert( result == H264_RESULT_OK );
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = mtuSize;
+    result = H264Packetizer_GetPacket( &( ctx ),
+                                       &( pkt ) );
+
+    while( result != H264_RESULT_NO_MORE_PACKETS )
+    {
+        packetNumber++;
+        assert( expectedPacketLength[i++] == pkt.packetDataLength );
+        //DumpPacket( &( pkt ), packetNumber );
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = mtuSize;
+        result = H264Packetizer_GetPacket( &( ctx ),
+                                           &( pkt ) );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+void GenerateNalus( uint8_t * pFrame,
+                    size_t frameLength )
+{
+    int naluNumber = 0, packetNumber = 0;
+    size_t curIndex = 0, naluStartIndex = 0, remainingLength;
+    uint32_t fistStartCode = 1, i = 0;
+    H264Result_t result;
+    size_t naluLength;
+    uint8_t startCode[] = { 0x00, 0x00, 0x00, 0x01 };
+    uint32_t expectedPacketLength[] = { 2, 12, 4, 12, 21, 12 };
+
+    while( curIndex < frameLength )
+    {
+        remainingLength = frameLength - curIndex;
+
+        /* Check the presence of 4 byte start code. */
+        if( remainingLength >= sizeof( startCode ) )
+        {
+            if( memcmp( &( pFrame[ curIndex ] ),
+                        &( startCode[ 0 ] ),
+                        sizeof( startCode ) ) == 0 )
+            {
+                if( fistStartCode == 1 )
+                {
+                    fistStartCode = 0;
+                }
+                else
+                {
+                    naluNumber++;
+                    naluLength = curIndex - naluStartIndex;
+                    assert( expectedPacketLength[i++] == naluLength );
+                    //DumpNalu( &(pFrame[ naluStartIndex ]), naluLength, naluNumber);
+                }
+
+                naluStartIndex = curIndex + sizeof( startCode );
+                curIndex = curIndex + sizeof( startCode );
+                continue;
+            }
+        }
+
+        curIndex += 1;
+    }
+
+    if( naluStartIndex > 0 )
+    {
+        naluNumber++;
+        naluLength = frameLength - naluStartIndex;
+        assert( expectedPacketLength[i++] == naluLength );
+        //DumpNalu( &(pFrame[ naluStartIndex ]), naluLength, naluNumber);
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+void h264Packetizer()
+{
+    int i;
+    FILE * fp;
+    uint8_t pFrame[] = { 0x00, 0x00, 0x00, 0x01, 0x09, 0x10,
+                         0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xec, 0x05, 0xa8, 0x08,
+                         0x00, 0x00, 0x00, 0x01, 0x68, 0xce, 0x3c, 0x80,
+                         0x00, 0x00, 0x00, 0x01, 0x06, 0x05, 0xff, 0xff, 0xb7, 0xdc, 0x45, 0xe9, 0xbd, 0xe6, 0xd9, 0x48,
+                         0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x84, 0x12, 0xff, 0xff, 0xfc, 0x3d, 0x14, 0x00, 0x04, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba,
+                         0x00, 0x00, 0x00, 0x01, 0x65, 0x00, 0x6e, 0x22, 0x21, 0x04, 0xbf, 0xff, 0xff, 0x0f, 0x45, 0x00 };
+    size_t frameLength = sizeof( pFrame );
+
+    ProcessFrame( &( pFrame[ 0 ] ),
+                  frameLength );
+}
+
+void h264Packetizer_2()
+{
+    int i;
+    FILE * fp;
+    uint8_t pFrame[] = { 0x00, 0x00, 0x00, 0x01, 0x09, 0x10,
+                         0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xec, 0x05, 0xa8, 0x08,
+                         0x00, 0x00, 0x00, 0x01, 0x68, 0xce, 0x3c, 0x80,
+                         0x00, 0x00, 0x00, 0x01, 0x06, 0x05, 0xff, 0xff, 0xb7, 0xdc, 0x45, 0xe9, 0xbd, 0xe6, 0xd9, 0x48,
+                         0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x84, 0x12, 0xff, 0xff, 0xfc, 0x3d, 0x14, 0x00, 0x04, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba,
+                         0x00, 0x00, 0x00, 0x01, 0x65, 0x00, 0x6e, 0x22, 0x21, 0x04, 0xbf, 0xff, 0xff, 0x0f, 0x45, 0x00 };
+    size_t frameLength = sizeof( pFrame );
+
+    ProcessFrame2( &( pFrame[ 0 ] ),
+                   frameLength );
+}
+
+void h264Packetizer_3()
+{
+    int i;
+    FILE * fp;
+    uint8_t pFrame[] = { 0x00, 0x00, 0x00, 0x01, 0x09, 0x10,
+                         0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xec, 0x05, 0xa8, 0x08,
+                         0x00, 0x00, 0x00, 0x01, 0x68, 0xce, 0x3c, 0x80,
+                         0x00, 0x00, 0x00, 0x01, 0x06, 0x05, 0xff, 0xff, 0xb7, 0xdc, 0x45, 0xe9, 0xbd, 0xe6, 0xd9, 0x48,
+                         0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x84, 0x12, 0xff, 0xff, 0xfc, 0x3d, 0x14, 0x00, 0x04, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba,
+                         0x00, 0x00, 0x00, 0x01, 0x65, 0x00, 0x6e, 0x22, 0x21, 0x04, 0xbf, 0xff, 0xff, 0x0f, 0x45, 0x00 };
+    size_t frameLength = sizeof( pFrame );
+
+    GenerateNalus( &( pFrame[ 0 ] ),
+                   frameLength );
+}
+
+/*-----------------------------------------------------------*/
+
+void g711Packetizer()
+{
+    G711Result_t result;
+    uint8_t frameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                            0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                            0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                            0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                            0x40, 0x41 };
+    G711PacketizerContext_t ctx;
+    G711Packet_t pkt;
+    G711Frame_t frame;
+    uint8_t pktBuffer[ G711_PACKET_LENGTH ];
+    size_t i, curFrameDataIndex = 0;
+
+    frame.pFrameData = &( frameData [ 0 ] );
+    frame.frameDataLength = sizeof( frameData );
+
+    result = G711Packetizer_Init( &( ctx ),
+                                  &( frame ) );
+    assert( result == G711_RESULT_OK );
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = G711_PACKET_LENGTH;
+    result = G711Packetizer_GetPacket( &( ctx ),
+                                       &( pkt ) );
+
+    while( result != VP8_RESULT_NO_MORE_PACKETS )
+    {
+        assert( pkt.packetDataLength <= G711_PACKET_LENGTH );
+        for( i = 0; i < pkt.packetDataLength; i++ )
+        {
+            assert( pkt.pPacketData[ i ] == frameData[ curFrameDataIndex ] );
+            curFrameDataIndex++;
+        }
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = G711_PACKET_LENGTH;
+        result = G711Packetizer_GetPacket( &( ctx ),
+                                           &( pkt ) );
+    }
+
+    assert( curFrameDataIndex == sizeof( frameData ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void OpusPacketizer()
+{
+    OpusResult_t result;
+    uint8_t frameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                            0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                            0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                            0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                            0x40, 0x41 };
+    OpusPacketizerContext_t ctx;
+    OpusPacket_t pkt;
+    OpusFrame_t frame;
+    uint8_t pktBuffer[ OPUS_PACKET_LENGTH ];
+    size_t i, curFrameDataIndex = 0;
+
+    frame.pFrameData = &( frameData [ 0 ] );
+    frame.frameDataLength = sizeof( frameData );
+
+    result = OpusPacketizer_Init( &( ctx ),
+                                  &( frame ) );
+    assert( result == OPUS_RESULT_OK );
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = OPUS_PACKET_LENGTH;
+    result = OpusPacketizer_GetPacket( &( ctx ),
+                                       &( pkt ) );
+
+    while( result != OPUS_RESULT_NO_MORE_PACKETS )
+    {
+        assert( pkt.packetDataLength <= OPUS_PACKET_LENGTH );
+        for( i = 0; i < pkt.packetDataLength; i++ )
+        {
+            assert( pkt.pPacketData[ i ] == frameData[ curFrameDataIndex ] );
+            curFrameDataIndex++;
+        }
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = OPUS_PACKET_LENGTH;
+        result = OpusPacketizer_GetPacket( &( ctx ),
+                                           &( pkt ) );
+    }
+
+    assert( curFrameDataIndex == sizeof( frameData ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void vp8Packetizer_1()
+{
+    VP8Result_t result;
+    uint8_t frameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                            0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                            0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                            0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                            0x40, 0x41 };
+    VP8PacketizerContext_t ctx;
+    VP8Frame_t frame;
+    uint8_t pktBuffer[ VP8_PACKET_LENGTH ];
+    VP8Packet_t pkt;
+    uint8_t payloadDescFirstPkt[] = { 0x10 };
+    uint8_t payloadDesc[] = { 0x00 };
+    size_t i, frameDataIndex = 0;
+
+    memset( &( frame ),
+            0,
+            sizeof( VP8Frame_t ) );
+
+    frame.pFrameData = &( frameData[ 0 ] );
+    frame.frameDataLength = sizeof( frameData );
+
+    result = VP8Packetizer_Init( &( ctx ),
+                                 &( frame ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+    result = VP8Packetizer_GetPacket( &( ctx ),
+                                      &( pkt ) );
+
+    while( result != VP8_RESULT_NO_MORE_PACKETS )
+    {
+        //printf( "Packet Length: %lu.\n", pkt.packetDataLength );
+        for( i = 0; i < pkt.packetDataLength; i++ )
+        {
+            if( i < sizeof( payloadDesc ) )
+            {
+                if( frameDataIndex == 0 )
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDescFirstPkt[ i ] );
+                }
+                else
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDesc[ i ] );
+                }
+            }
+            else
+            {
+                assert( pkt.pPacketData[ i ] == frameData[ frameDataIndex ] );
+                frameDataIndex++;
+            }
+        }
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+        result = VP8Packetizer_GetPacket( &( ctx ),
+                                          &( pkt ) );
+
+    }
+
+    assert( frameDataIndex == sizeof( frameData ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void vp8Packetizer_2()
+{
+    VP8Result_t result;
+    uint8_t frameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                            0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                            0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                            0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                            0x40, 0x41 };
+    VP8PacketizerContext_t ctx;
+    VP8Frame_t frame;
+    uint8_t pktBuffer[ VP8_PACKET_LENGTH ];
+    VP8Packet_t pkt;
+    uint8_t payloadDescFirstPkt[] = { 0xB0, 0x80, 0x1A };
+    uint8_t payloadDesc[] = { 0xA0, 0x80, 0x1A };
+    size_t i, frameDataIndex = 0;
+
+    memset( &( frame ),
+            0,
+            sizeof( VP8Frame_t ) );
+
+    frame.frameProperties |= VP8_FRAME_PROP_NON_REF_FRAME;
+    frame.frameProperties |= VP8_FRAME_PROP_PICTURE_ID_PRESENT;
+    frame.pictureId = 0x1A;
+    frame.pFrameData = &( frameData[ 0 ] );
+    frame.frameDataLength = sizeof( frameData );
+
+    result = VP8Packetizer_Init( &( ctx ),
+                                 &( frame ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+    result = VP8Packetizer_GetPacket( &( ctx ),
+                                      &( pkt ) );
+
+    while( result != VP8_RESULT_NO_MORE_PACKETS )
+    {
+        //printf( "Packet Length: %lu.\n", pkt.packetDataLength );
+        for( i = 0; i < pkt.packetDataLength; i++ )
+        {
+            if( i < sizeof( payloadDesc ) )
+            {
+                if( frameDataIndex == 0 )
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDescFirstPkt[ i ] );
+                }
+                else
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDesc[ i ] );
+                }
+            }
+            else
+            {
+                assert( pkt.pPacketData[ i ] == frameData[ frameDataIndex ] );
+                frameDataIndex++;
+            }
+        }
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+        result = VP8Packetizer_GetPacket( &( ctx ),
+                                          &( pkt ) );
+
+    }
+
+    assert( frameDataIndex == sizeof( frameData ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void vp8Packetizer_3()
+{
+    VP8Result_t result;
+    uint8_t frameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                            0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                            0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                            0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                            0x40, 0x41 };
+    VP8PacketizerContext_t ctx;
+    VP8Frame_t frame;
+    uint8_t pktBuffer[ VP8_PACKET_LENGTH ];
+    VP8Packet_t pkt;
+    uint8_t payloadDescFirstPkt[] = { 0xB0, 0x20, 0x60 };
+    uint8_t payloadDesc[] = { 0xA0, 0x20, 0x60 };
+    size_t i, frameDataIndex = 0;
+
+    memset( &( frame ),
+            0,
+            sizeof( VP8Frame_t ) );
+
+    frame.frameProperties |= VP8_FRAME_PROP_NON_REF_FRAME;
+    frame.frameProperties |= VP8_FRAME_PROP_TID_PRESENT;
+    frame.tid = 3;
+    frame.pFrameData = &( frameData[ 0 ] );
+    frame.frameDataLength = sizeof( frameData );
+
+    result = VP8Packetizer_Init( &( ctx ),
+                                 &( frame ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+    result = VP8Packetizer_GetPacket( &( ctx ),
+                                      &( pkt ) );
+
+    while( result != VP8_RESULT_NO_MORE_PACKETS )
+    {
+        //printf( "Packet Length: %lu.\n", pkt.packetDataLength );
+        for( i = 0; i < pkt.packetDataLength; i++ )
+        {
+            if( i < sizeof( payloadDesc ) )
+            {
+                if( frameDataIndex == 0 )
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDescFirstPkt[ i ] );
+                }
+                else
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDesc[ i ] );
+                }
+            }
+            else
+            {
+                assert( pkt.pPacketData[ i ] == frameData[ frameDataIndex ] );
+                frameDataIndex++;
+            }
+        }
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+        result = VP8Packetizer_GetPacket( &( ctx ),
+                                          &( pkt ) );
+
+    }
+
+    assert( frameDataIndex == sizeof( frameData ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void vp8Packetizer_4()
+{
+    VP8Result_t result;
+    uint8_t frameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                            0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                            0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                            0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                            0x40, 0x41 };
+    VP8PacketizerContext_t ctx;
+    VP8Frame_t frame;
+    uint8_t pktBuffer[ VP8_PACKET_LENGTH ];
+    VP8Packet_t pkt;
+    uint8_t payloadDescFirstPkt[] = { 0xB0, 0x40, 0xAB };
+    uint8_t payloadDesc[] = { 0xA0, 0x40, 0xAB };
+    size_t i, frameDataIndex = 0;
+
+    memset( &( frame ),
+            0,
+            sizeof( VP8Frame_t ) );
+
+    frame.frameProperties |= VP8_FRAME_PROP_NON_REF_FRAME;
+    frame.frameProperties |= VP8_FRAME_PROP_TL0PICIDX_PRESENT;
+    frame.tl0PicIndex = 0xAB;
+    frame.pFrameData = &( frameData[ 0 ] );
+    frame.frameDataLength = sizeof( frameData );
+
+    result = VP8Packetizer_Init( &( ctx ),
+                                 &( frame ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+    result = VP8Packetizer_GetPacket( &( ctx ),
+                                      &( pkt ) );
+
+    while( result != VP8_RESULT_NO_MORE_PACKETS )
+    {
+        //printf( "Packet Length: %lu.\n", pkt.packetDataLength );
+        for( i = 0; i < pkt.packetDataLength; i++ )
+        {
+            if( i < sizeof( payloadDesc ) )
+            {
+                if( frameDataIndex == 0 )
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDescFirstPkt[ i ] );
+                }
+                else
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDesc[ i ] );
+                }
+            }
+            else
+            {
+                assert( pkt.pPacketData[ i ] == frameData[ frameDataIndex ] );
+                frameDataIndex++;
+            }
+        }
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+        result = VP8Packetizer_GetPacket( &( ctx ),
+                                          &( pkt ) );
+
+    }
+
+    assert( frameDataIndex == sizeof( frameData ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void vp8Packetizer_5()
+{
+    VP8Result_t result;
+    uint8_t frameData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                            0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+                            0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+                            0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
+                            0x40, 0x41 };
+    VP8PacketizerContext_t ctx;
+    VP8Frame_t frame;
+    uint8_t pktBuffer[ VP8_PACKET_LENGTH ];
+    VP8Packet_t pkt;
+    uint8_t payloadDescFirstPkt[] = { 0xB0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA };
+    uint8_t payloadDesc[] = { 0xA0, 0xF0, 0xFA, 0xCD, 0xAB, 0xBA };
+    size_t i, frameDataIndex = 0;
+
+    memset( &( frame ),
+            0,
+            sizeof( VP8Frame_t ) );
+
+    frame.frameProperties |= VP8_FRAME_PROP_NON_REF_FRAME;
+    frame.frameProperties |= VP8_FRAME_PROP_PICTURE_ID_PRESENT;
+    frame.frameProperties |= VP8_FRAME_PROP_TL0PICIDX_PRESENT;
+    frame.frameProperties |= VP8_FRAME_PROP_TID_PRESENT;
+    frame.frameProperties |= VP8_FRAME_PROP_KEYIDX_PRESENT;
+    frame.frameProperties |= VP8_FRAME_PROP_DEPENDS_ON_BASE_ONLY;
+    frame.pictureId = 0x7ACD;
+    frame.tl0PicIndex = 0xAB;
+    frame.tid = 5;
+    frame.keyIndex = 10;
+    frame.pFrameData = &( frameData[ 0 ] );
+    frame.frameDataLength = sizeof( frameData );
+
+    result = VP8Packetizer_Init( &( ctx ),
+                                 &( frame ) );
+    assert( result == VP8_RESULT_OK );
+
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+    result = VP8Packetizer_GetPacket( &( ctx ),
+                                      &( pkt ) );
+
+    while( result != VP8_RESULT_NO_MORE_PACKETS )
+    {
+        //printf( "Packet Length: %lu.\n", pkt.packetDataLength );
+        for( i = 0; i < pkt.packetDataLength; i++ )
+        {
+            if( i < sizeof( payloadDesc ) )
+            {
+                if( frameDataIndex == 0 )
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDescFirstPkt[ i ] );
+                }
+                else
+                {
+                    assert( pkt.pPacketData[ i ] == payloadDesc[ i ] );
+                }
+            }
+            else
+            {
+                assert( pkt.pPacketData[ i ] == frameData[ frameDataIndex ] );
+                frameDataIndex++;
+            }
+        }
+
+        pkt.pPacketData = &( pktBuffer[ 0 ] );
+        pkt.packetDataLength = VP8_PACKET_LENGTH;
+
+        result = VP8Packetizer_GetPacket( &( ctx ),
+                                          &( pkt ) );
+
+    }
+
+    assert( frameDataIndex == sizeof( frameData ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void H264_test_case()
+{
+    printf( "\nRunning H264 Test Cases\n" );
+    h264Packetizer();
+    printf( "\tTest 1 - H264 packetize Test to generate packet1 passed\n" );
+    h264Packetizer_2();
+    printf( "\tTest 2 - H264 packetize Test to generate packet2 passed\n" );
+    h264Packetizer_3();
+    printf( "\tTest 3 - H264 packetize Test to generate Nalus passed\n" );
+}
+
+void VP8_test_case()
+{
+    printf( "\nRunning VP8 Test Cases\n" );
+    vp8Packetizer_1();
+    printf( "\tTest 1 - VP8 packetize Test passed\n" );
+    vp8Packetizer_2();
+    printf( "\tTest 2 - VP8 packetize Test passed\n" );
+    vp8Packetizer_3();
+    printf( "\tTest 3 - VP8 packetize Test passed\n" );
+    vp8Packetizer_4();
+    printf( "\tTest 4 - VP8 packetize Test passed\n" );
+    vp8Packetizer_5();
+    printf( "\tTest 5 - VP8 packetize Test passed\n" );
+}
+
+void G711_test_case()
+{
+    printf( "\nRunning G711 Test Cases\n" );
+    g711Packetizer();
+    printf( "\tTest 1 - G711 packetize Test passed\n" );
+}
+
+void Opus_test_case()
+{
+    printf( "\nRunning Opus Test Cases\n" );
+    OpusPacketizer();
+    printf( "\tTest 1 - Opus packetize Test passed\n" );
+}
+
+int main( void )
+{
+    H264_test_case();
+
+    VP8_test_case();
+
+    G711_test_case();
+
+    Opus_test_case();
+
+}
+
+/*-----------------------------------------------------------*/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add test cases for packetization and de-packetization for following Codecs : 
- H.264
- G.711
- Opus
- VP8 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
