### PR TITLE
Make coverage target work on Linux & Mac and remove unused 'totalSize'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "test/CMock"]
 	path = test/CMock
-	url = git@github.com:ThrowTheSwitch/CMock.git
+	url = https://github.com/ThrowTheSwitch/CMock.git
 	update = none

--- a/README.md
+++ b/README.md
@@ -117,20 +117,10 @@ git submodule update --checkout --init --recursive test/CMock
 
 ### Steps to generate code coverage report of Unit Test
 1. Run Unit Tests in [Steps to build Unit Tests](#steps-to-build-unit-tests).
-1. Generate coverage.info in build folder:
+2. Generate coverage report in 'build/coverage' folder:
 
     ```
     make coverage
-    ```
-1. Get code coverage by lcov:
-
-    ```
-    lcov --rc lcov_branch_coverage=1 -r coverage.info -o coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
-    ```
-1. Generage HTML report in folder `CodecovHTMLReport`:
-
-    ```
-    genhtml --rc lcov_branch_coverage=1 --ignore-errors source coverage.info --legend --output-directory=CodecovHTMLReport
     ```
 
 ### Script to run Unit Test and generate code coverage report
@@ -142,8 +132,6 @@ make -C build all
 cd build
 ctest -E system --output-on-failure
 make coverage
-lcov --rc lcov_branch_coverage=1 -r coverage.info -o coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
-genhtml --rc lcov_branch_coverage=1 --ignore-errors source coverage.info --legend --output-directory=CodecovHTMLReport
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ git submodule update --checkout --init --recursive test/CMock
 
 ### Steps to generate code coverage report of Unit Test
 1. Run Unit Tests in [Steps to build Unit Tests](#steps-to-build-unit-tests).
-2. Generate coverage report in 'build/coverage' folder:
+1. Generate coverage report in 'build/coverage' folder:
 
     ```
     make coverage

--- a/test/unit-test/README.md
+++ b/test/unit-test/README.md
@@ -64,7 +64,7 @@ popd
 
 # Calculate the coverage
 make -C ${BUILD_DIR}/ coverage
-
+```
 
 You should see an output similar to this:
 

--- a/test/unit-test/README.md
+++ b/test/unit-test/README.md
@@ -64,12 +64,7 @@ popd
 
 # Calculate the coverage
 make -C ${BUILD_DIR}/ coverage
-lcov --rc lcov_branch_coverage=1 -r ${BUILD_DIR}/coverage.info -o ${BUILD_DIR}/coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
-lcov --rc lcov_branch_coverage=1 --list ${BUILD_DIR}/coverage.info
 
-# Generate HTML coverage report
-genhtml ${BUILD_DIR}/coverage.info -o ${BUILD_DIR}/htmlout
-```
 
 You should see an output similar to this:
 

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -52,7 +52,7 @@ execute_process(
                          --base-directory ${CMAKE_BINARY_DIR}
                          --directory ${CMAKE_BINARY_DIR}
                          --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
-                          --include "*source*"
+                         --include "*source*"
                          --include "*codec_packetizers*"
         )
 
@@ -71,5 +71,5 @@ execute_process(
             COMMAND genhtml --rc branch_coverage=1
                             --branch-coverage
                             --output-directory ${CMAKE_BINARY_DIR}/coverage
-                                ${CMAKE_BINARY_DIR}/coverage.info
+                            ${CMAKE_BINARY_DIR}/coverage.info
         )

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -15,9 +15,10 @@ execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
                          --base-directory ${CMAKE_BINARY_DIR}
                          --initial
                          --capture
-                         --rc lcov_branch_coverage=1
-                         --rc genhtml_branch_coverage=1
+                         --rc branch_coverage=1
                          --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
+                         --include "*source*"
+                         --include "*codec_packetizers*"
         )
 file(GLOB files "${CMAKE_BINARY_DIR}/bin/tests/*")
 
@@ -47,11 +48,12 @@ execute_process(COMMAND ruby
 # Capture data after running the tests.
 execute_process(
             COMMAND lcov --capture
-                         --rc lcov_branch_coverage=1
-                         --rc genhtml_branch_coverage=1
+                         --rc branch_coverage=1
                          --base-directory ${CMAKE_BINARY_DIR}
                          --directory ${CMAKE_BINARY_DIR}
                          --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
+                          --include "*source*"
+                         --include "*codec_packetizers*"
         )
 
 # Combile baseline results (zeros) with the one after running the tests.
@@ -61,11 +63,12 @@ execute_process(
                          --add-tracefile ${CMAKE_BINARY_DIR}/base_coverage.info
                          --add-tracefile ${CMAKE_BINARY_DIR}/second_coverage.info
                          --output-file ${CMAKE_BINARY_DIR}/coverage.info
-                         --no-external
-                         --rc lcov_branch_coverage=1
+                         --rc branch_coverage=1
+                         --include "*source*"
+                         --include "*codec_packetizers*"
         )
 execute_process(
-            COMMAND genhtml --rc lcov_branch_coverage=1
+            COMMAND genhtml --rc branch_coverage=1
                             --branch-coverage
                             --output-directory ${CMAKE_BINARY_DIR}/coverage
                                 ${CMAKE_BINARY_DIR}/coverage.info

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -15,7 +15,7 @@ execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
                          --base-directory ${CMAKE_BINARY_DIR}
                          --initial
                          --capture
-                         --rc branch_coverage=1
+                         --rc lcov_branch_coverage=1
                          --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
                          --include "*source*"
                          --include "*codec_packetizers*"
@@ -48,7 +48,7 @@ execute_process(COMMAND ruby
 # Capture data after running the tests.
 execute_process(
             COMMAND lcov --capture
-                         --rc branch_coverage=1
+                         --rc lcov_branch_coverage=1
                          --base-directory ${CMAKE_BINARY_DIR}
                          --directory ${CMAKE_BINARY_DIR}
                          --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
@@ -63,12 +63,12 @@ execute_process(
                          --add-tracefile ${CMAKE_BINARY_DIR}/base_coverage.info
                          --add-tracefile ${CMAKE_BINARY_DIR}/second_coverage.info
                          --output-file ${CMAKE_BINARY_DIR}/coverage.info
-                         --rc branch_coverage=1
+                         --rc lcov_branch_coverage=1
                          --include "*source*"
                          --include "*codec_packetizers*"
         )
 execute_process(
-            COMMAND genhtml --rc branch_coverage=1
+            COMMAND genhtml --rc lcov_branch_coverage=1
                             --branch-coverage
                             --output-directory ${CMAKE_BINARY_DIR}/coverage
                             ${CMAKE_BINARY_DIR}/coverage.info

--- a/test/unit-test/cmock/create_test.cmake
+++ b/test/unit-test/cmock/create_test.cmake
@@ -20,9 +20,6 @@ function(create_test test_name
             COMPILE_FLAG "-O0 -ggdb"
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/tests"
             INSTALL_RPATH_USE_LINK_PATH TRUE
-            LINK_FLAGS " \
-                -Wl,-rpath,${CMAKE_BINARY_DIR}/lib \
-                -Wl,-rpath,${CMAKE_CURRENT_BINARY_DIR}/lib"
         )
     target_include_directories(${test_name} PUBLIC
                                ${mocks_dir}
@@ -43,7 +40,7 @@ function(create_test test_name
         add_dependencies(${test_name} ${dependency})
         target_link_libraries(${test_name} ${dependency})
     endforeach()
-    target_link_libraries(${test_name} -lgcov unity)
+    target_link_libraries(${test_name} unity)
     target_link_directories(${test_name}  PUBLIC
                             ${CMAKE_CURRENT_BINARY_DIR}/lib
             )
@@ -127,10 +124,19 @@ function(create_mock_list mock_name
                                ${mocks_dir}
                                ${mock_include_list}
            )
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(${mock_name} PROPERTIES
-                        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
-                        POSITION_INDEPENDENT_CODE ON
-            )
+                            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                            POSITION_INDEPENDENT_CODE ON
+                            LINK_FLAGS "-Wl,-undefined,dynamic_lookup"
+                        )
+    else()
+    set_target_properties(${mock_name} PROPERTIES
+                            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                            POSITION_INDEPENDENT_CODE ON
+                        )
+    endif()
+       
     target_compile_definitions(${mock_name} PUBLIC
             ${mock_define_list}
         )
@@ -160,7 +166,6 @@ function(create_real_library target
         add_dependencies(${target} ${mock_name})
         target_link_libraries(${target}
                         -l${mock_name}
-                        -lgcov
                 )
     endif()
 endfunction()

--- a/test/unit-test/cmock/create_test.cmake
+++ b/test/unit-test/cmock/create_test.cmake
@@ -124,19 +124,20 @@ function(create_mock_list mock_name
                                ${mocks_dir}
                                ${mock_include_list}
            )
+
     if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set_target_properties(${mock_name} PROPERTIES
-                            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
-                            POSITION_INDEPENDENT_CODE ON
-                            LINK_FLAGS "-Wl,-undefined,dynamic_lookup"
-                        )
+        set_target_properties(${mock_name} PROPERTIES
+                              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                              POSITION_INDEPENDENT_CODE ON
+                              LINK_FLAGS "-Wl,-undefined,dynamic_lookup"
+                             )
     else()
-    set_target_properties(${mock_name} PROPERTIES
-                            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
-                            POSITION_INDEPENDENT_CODE ON
-                        )
+        set_target_properties(${mock_name} PROPERTIES
+                              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                              POSITION_INDEPENDENT_CODE ON
+                             )
     endif()
-       
+
     target_compile_definitions(${mock_name} PUBLIC
             ${mock_define_list}
         )

--- a/test/unit-test/depacketization/depacketization_utest.c
+++ b/test/unit-test/depacketization/depacketization_utest.c
@@ -467,7 +467,6 @@ void test_H264_Depacketizer_GetFrame( void )
     uint8_t packetData5[] = { 0x7c, 0x85, 0x88, 0x84, 0x12, 0xff, 0xff, 0xfc, 0x3d, 0x14, 0x0, 0x4 };
     uint8_t packetData6[] = { 0x7c, 0x45, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba, 0xeb, 0xae, 0xba };
     uint8_t packetData7[] = { 0x65, 0x00, 0x6e, 0x22, 0x21, 0x04, 0xbf, 0xff, 0xff, 0x0f, 0x45, 0x00 };
-    uint32_t totalSize = 0;
     result = H264Depacketizer_Init( &( ctx ),
                                     &( packetsArray[ 0 ] ),
                                     MAX_PACKETS_IN_A_FRAME );
@@ -476,7 +475,6 @@ void test_H264_Depacketizer_GetFrame( void )
 
     pkt.pPacketData = &( packetData1[ 0 ] );
     pkt.packetDataLength = sizeof( packetData1 );
-    totalSize += pkt.packetDataLength;
     result = H264Depacketizer_AddPacket( &( ctx ),
                                          &( pkt ) );
     TEST_ASSERT_EQUAL( result,
@@ -484,7 +482,6 @@ void test_H264_Depacketizer_GetFrame( void )
 
     pkt.pPacketData = &( packetData2[ 0 ] );
     pkt.packetDataLength = sizeof( packetData2 );
-    totalSize += pkt.packetDataLength;
     result = H264Depacketizer_AddPacket( &( ctx ),
                                          &( pkt ) );
     TEST_ASSERT_EQUAL( result,
@@ -492,7 +489,6 @@ void test_H264_Depacketizer_GetFrame( void )
 
     pkt.pPacketData = &( packetData3[ 0 ] );
     pkt.packetDataLength = sizeof( packetData3 );
-    totalSize += pkt.packetDataLength;
     result = H264Depacketizer_AddPacket( &( ctx ),
                                          &( pkt ) );
     TEST_ASSERT_EQUAL( result,
@@ -500,7 +496,6 @@ void test_H264_Depacketizer_GetFrame( void )
 
     pkt.pPacketData = &( packetData4[ 0 ] );
     pkt.packetDataLength = sizeof( packetData4 );
-    totalSize += pkt.packetDataLength;
     result = H264Depacketizer_AddPacket( &( ctx ),
                                          &( pkt ) );
     TEST_ASSERT_EQUAL( result,
@@ -508,7 +503,6 @@ void test_H264_Depacketizer_GetFrame( void )
 
     pkt.pPacketData = &( packetData5[ 0 ] );
     pkt.packetDataLength = sizeof( packetData5 );
-    totalSize += pkt.packetDataLength;
     result = H264Depacketizer_AddPacket( &( ctx ),
                                          &( pkt ) );
     TEST_ASSERT_EQUAL( result,
@@ -516,7 +510,6 @@ void test_H264_Depacketizer_GetFrame( void )
 
     pkt.pPacketData = &( packetData6[ 0 ] );
     pkt.packetDataLength = sizeof( packetData6 );
-    totalSize += pkt.packetDataLength;
     result = H264Depacketizer_AddPacket( &( ctx ),
                                          &( pkt ) );
     TEST_ASSERT_EQUAL( result,
@@ -524,7 +517,6 @@ void test_H264_Depacketizer_GetFrame( void )
 
     pkt.pPacketData = &( packetData7[ 0 ] );
     pkt.packetDataLength = sizeof( packetData7 );
-    totalSize += pkt.packetDataLength;
     result = H264Depacketizer_AddPacket( &( ctx ),
                                          &( pkt ) );
     TEST_ASSERT_EQUAL( result,

--- a/test/unit-test/depacketization/ut.cmake
+++ b/test/unit-test/depacketization/ut.cmake
@@ -71,7 +71,6 @@ create_real_library(${real_name}
         )
 
 list(APPEND utest_link_list
-            -l${mock_name}
             lib${real_name}.a
         )
 

--- a/test/unit-test/packetization/ut.cmake
+++ b/test/unit-test/packetization/ut.cmake
@@ -71,7 +71,6 @@ create_real_library(${real_name}
         )
 
 list(APPEND utest_link_list
-            -l${mock_name}
             lib${real_name}.a
         )
 

--- a/test/unit-test/rtp_packet_queue/ut.cmake
+++ b/test/unit-test/rtp_packet_queue/ut.cmake
@@ -65,7 +65,6 @@ create_real_library(${real_name}
         )
 
 list(APPEND utest_link_list
-            -l${mock_name}
             lib${real_name}.a
         )
 


### PR DESCRIPTION
Description
-----------
- Changes have been made in create_test.cmake and ut.cmake to fix failures on mac and linux
- There are changes in coverage.cmake to make coverage target work
- The variable totalSize is declared and initialized to 0 in the test_H264_Depacketizer_GetFrame function, but it is never used in the code. This commit removes the declaration and all occurrences of totalSize from depacketization_utest.c

Test Steps
-----------
The following unit-tests are successfully running after this commit changes.
- packetization_utest
- depacketization_utest 
- rtp_packet_queue_utest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
