### PR TITLE
Add unit tests for rtp_pkt_queue.c file

### DIFF
--- a/test/unit-test/rtp_packet_queue/rtp_packet_queue_utest.c
+++ b/test/unit-test/rtp_packet_queue/rtp_packet_queue_utest.c
@@ -51,6 +51,66 @@ void test_RtpPacketQueue_Init( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate RtpPacketQueue_Init functionality for BAD_PARAM
+ */
+void test_RtpPacketQueue_Init_Fail( void )
+{
+    RtpPacketQueueResult_t result;
+
+    result = RtpPacketQueue_Init( NULL,
+                                  &( rtpPacketInfoArray[ 0 ] ),
+                                  MAX_IN_FLIGHT_PKTS );
+
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
+    TEST_ASSERT_EQUAL( &( rtpPacketInfoArray[ 0 ] ), rtpPacketQueue.pRtpPacketInfoArray );
+    TEST_ASSERT_EQUAL( MAX_IN_FLIGHT_PKTS, rtpPacketQueue.rtpPacketInfoArrayLength );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.readIndex );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.writeIndex );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.packetCount );
+
+    result = RtpPacketQueue_Init( &( rtpPacketQueue ),
+                                  NULL,
+                                  MAX_IN_FLIGHT_PKTS );
+
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
+    TEST_ASSERT_EQUAL( &( rtpPacketInfoArray[ 0 ]), rtpPacketQueue.pRtpPacketInfoArray );
+    TEST_ASSERT_EQUAL( MAX_IN_FLIGHT_PKTS, rtpPacketQueue.rtpPacketInfoArrayLength );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.readIndex );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.writeIndex );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.packetCount );
+
+    result = RtpPacketQueue_Init( &( rtpPacketQueue ),
+                                   &( rtpPacketInfoArray[ 0 ]),
+                                  1 );
+
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
+    TEST_ASSERT_EQUAL( &( rtpPacketInfoArray[ 0 ]), rtpPacketQueue.pRtpPacketInfoArray );
+    TEST_ASSERT_EQUAL( MAX_IN_FLIGHT_PKTS, rtpPacketQueue.rtpPacketInfoArrayLength );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.readIndex );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.writeIndex );
+    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.packetCount );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Enqueue functionality for BAD_PARAM
+ */
+void test_RtpPacketQueue_Enqueue_Fail( void )
+{
+    RtpPacketQueueResult_t result;
+    RtpPacketInfo_t rtpPacketInfo;
+
+    result = RtpPacketQueue_Enqueue(NULL, &( rtpPacketInfo ));
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+
+    result = RtpPacketQueue_Enqueue(&( rtpPacketQueue ), NULL);
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Add packets in the RTP packet Queue.
  */
 void test_RtpPacketQueue_ForceEnqueue( void )
@@ -143,6 +203,25 @@ void test_RtpPacketQueue_ForceEnqueue_Full( void )
     TEST_ASSERT_EQUAL( 1, deletedRtpPacketInfo.seqNum ); /* Second packet deleted. */
 }
 
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Forced Enqueue if Queue or RtpPacketInfo or DeletedRtpPacketInfo is NULL
+ */
+void test_RtpPacketQueue_ForceEnqueue_Fail( void )
+{
+    RtpPacketQueueResult_t result;
+    RtpPacketInfo_t deletedRtpPacketInfo,rtpPacketInfo;
+
+    result = RtpPacketQueue_ForceEnqueue(NULL, &( rtpPacketInfo ), &(deletedRtpPacketInfo));
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+
+    result = RtpPacketQueue_ForceEnqueue(&( rtpPacketQueue ), NULL , &(deletedRtpPacketInfo));
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+
+    result = RtpPacketQueue_ForceEnqueue(&( rtpPacketQueue ), &( rtpPacketInfo ), NULL);
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+}
 /*-----------------------------------------------------------*/
 
 /**
@@ -272,6 +351,22 @@ void test_RtpPacketQueue_Peek( void )
                        &( rtpPacketInfo.pSerializedRtpPacket[ 0 ] ) );
 }
 
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Peek functionality when Queue or RtpPacketinfo is NULL
+ */
+void test_RtpPacketQueue_Peek_Fail( void )
+{
+    RtpPacketQueueResult_t result;
+    RtpPacketInfo_t rtpPacketInfo;
+
+    result = RtpPacketQueue_Peek(NULL, &( rtpPacketInfo ) );
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+
+    result = RtpPacketQueue_Peek(&( rtpPacketQueue ), NULL);
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+}
 /*-----------------------------------------------------------*/
 
 /**
@@ -434,3 +529,22 @@ void test_RtpPacketQueue_Retrieve( void )
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate retrieve functionality when Queue or RtpPacketinfo is NULL
+ */
+
+void test_RtpPacketQueue_Retrieve_Fail( void )
+{
+    RtpPacketQueueResult_t result;
+    RtpPacketInfo_t rtpPacketInfo;
+
+    result = RtpPacketQueue_Retrieve(NULL, 8 , &( rtpPacketInfo ) );
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+
+    result = RtpPacketQueue_Retrieve(&( rtpPacketQueue ), 8, NULL);
+    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+}
+
+/*-----------------------------------------------------------*/
+

--- a/test/unit-test/rtp_packet_queue/rtp_packet_queue_utest.c
+++ b/test/unit-test/rtp_packet_queue/rtp_packet_queue_utest.c
@@ -18,6 +18,9 @@ RtpPacketQueue_t rtpPacketQueue;
 
 void setUp( void )
 {
+    memset( &( rtpPacketQueue ),
+            0,
+            sizeof( rtpPacketQueue ) );
     memset( &( rtpPacketInfoArray[ 0 ] ),
             0,
             sizeof( sizeof( RtpPacketInfo_t ) * MAX_IN_FLIGHT_PKTS ) );
@@ -51,9 +54,9 @@ void test_RtpPacketQueue_Init( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate RtpPacketQueue_Init functionality for BAD_PARAM
+ * @brief Validate RtpPacketQueue_Init functionality in case of bad parameters.
  */
-void test_RtpPacketQueue_Init_Fail( void )
+void test_RtpPacketQueue_Init_BadParams( void )
 {
     RtpPacketQueueResult_t result;
 
@@ -62,50 +65,35 @@ void test_RtpPacketQueue_Init_Fail( void )
                                   MAX_IN_FLIGHT_PKTS );
 
     TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
-    TEST_ASSERT_EQUAL( &( rtpPacketInfoArray[ 0 ] ), rtpPacketQueue.pRtpPacketInfoArray );
-    TEST_ASSERT_EQUAL( MAX_IN_FLIGHT_PKTS, rtpPacketQueue.rtpPacketInfoArrayLength );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.readIndex );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.writeIndex );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.packetCount );
 
     result = RtpPacketQueue_Init( &( rtpPacketQueue ),
                                   NULL,
                                   MAX_IN_FLIGHT_PKTS );
 
     TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
-    TEST_ASSERT_EQUAL( &( rtpPacketInfoArray[ 0 ]), rtpPacketQueue.pRtpPacketInfoArray );
-    TEST_ASSERT_EQUAL( MAX_IN_FLIGHT_PKTS, rtpPacketQueue.rtpPacketInfoArrayLength );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.readIndex );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.writeIndex );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.packetCount );
 
     result = RtpPacketQueue_Init( &( rtpPacketQueue ),
-                                   &( rtpPacketInfoArray[ 0 ]),
+                                  &( rtpPacketInfoArray[ 0 ] ),
                                   1 );
 
     TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
-    TEST_ASSERT_EQUAL( &( rtpPacketInfoArray[ 0 ]), rtpPacketQueue.pRtpPacketInfoArray );
-    TEST_ASSERT_EQUAL( MAX_IN_FLIGHT_PKTS, rtpPacketQueue.rtpPacketInfoArrayLength );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.readIndex );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.writeIndex );
-    TEST_ASSERT_EQUAL( 0, rtpPacketQueue.packetCount );
 }
 
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Enqueue functionality for BAD_PARAM
+ * @brief Validate Enqueue functionality in case of bad parameters.
  */
-void test_RtpPacketQueue_Enqueue_Fail( void )
+void test_RtpPacketQueue_Enqueue_BadParams( void )
 {
     RtpPacketQueueResult_t result;
-    RtpPacketInfo_t rtpPacketInfo;
+    RtpPacketInfo_t rtpPacketInfo = { 0 };
 
-    result = RtpPacketQueue_Enqueue(NULL, &( rtpPacketInfo ));
-    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+    result = RtpPacketQueue_Enqueue( NULL, &( rtpPacketInfo ) );
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
 
-    result = RtpPacketQueue_Enqueue(&( rtpPacketQueue ), NULL);
-    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+    result = RtpPacketQueue_Enqueue( &( rtpPacketQueue ), NULL );
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
 }
 
 /*-----------------------------------------------------------*/
@@ -206,21 +194,22 @@ void test_RtpPacketQueue_ForceEnqueue_Full( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Forced Enqueue if Queue or RtpPacketInfo or DeletedRtpPacketInfo is NULL
+ * @brief Validate Forced Enqueue in case of bad parameters.
  */
-void test_RtpPacketQueue_ForceEnqueue_Fail( void )
+void test_RtpPacketQueue_ForceEnqueue_BadParams( void )
 {
     RtpPacketQueueResult_t result;
-    RtpPacketInfo_t deletedRtpPacketInfo,rtpPacketInfo;
+    RtpPacketInfo_t deletedRtpPacketInfo = { 0 };
+    RtpPacketInfo_t rtpPacketInfo = { 0 };
 
-    result = RtpPacketQueue_ForceEnqueue(NULL, &( rtpPacketInfo ), &(deletedRtpPacketInfo));
+    result = RtpPacketQueue_ForceEnqueue( NULL, &( rtpPacketInfo ), &( deletedRtpPacketInfo ) );
     TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
 
-    result = RtpPacketQueue_ForceEnqueue(&( rtpPacketQueue ), NULL , &(deletedRtpPacketInfo));
-    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+    result = RtpPacketQueue_ForceEnqueue( &( rtpPacketQueue ), NULL, &( deletedRtpPacketInfo ) );
+    TEST_ASSERT_EQUAL (RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
 
-    result = RtpPacketQueue_ForceEnqueue(&( rtpPacketQueue ), &( rtpPacketInfo ), NULL);
-    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+    result = RtpPacketQueue_ForceEnqueue( &( rtpPacketQueue ), &( rtpPacketInfo ), NULL );
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
 }
 /*-----------------------------------------------------------*/
 
@@ -354,19 +343,20 @@ void test_RtpPacketQueue_Peek( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Peek functionality when Queue or RtpPacketinfo is NULL
+ * @brief Validate Peek functionality in case of bad parameters.
  */
-void test_RtpPacketQueue_Peek_Fail( void )
+void test_RtpPacketQueue_Peek_BadParams( void )
 {
     RtpPacketQueueResult_t result;
     RtpPacketInfo_t rtpPacketInfo;
 
-    result = RtpPacketQueue_Peek(NULL, &( rtpPacketInfo ) );
-    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+    result = RtpPacketQueue_Peek( NULL, &( rtpPacketInfo ) );
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
 
-    result = RtpPacketQueue_Peek(&( rtpPacketQueue ), NULL);
-    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+    result = RtpPacketQueue_Peek( &( rtpPacketQueue ), NULL);
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
 }
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -531,19 +521,18 @@ void test_RtpPacketQueue_Retrieve( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate retrieve functionality when Queue or RtpPacketinfo is NULL
+ * @brief Validate retrieve functionality in case of bad parameters.
  */
-
-void test_RtpPacketQueue_Retrieve_Fail( void )
+void test_RtpPacketQueue_Retrieve_BadParams( void )
 {
     RtpPacketQueueResult_t result;
     RtpPacketInfo_t rtpPacketInfo;
 
-    result = RtpPacketQueue_Retrieve(NULL, 8 , &( rtpPacketInfo ) );
-    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+    result = RtpPacketQueue_Retrieve( NULL, 8, &( rtpPacketInfo ) );
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
 
-    result = RtpPacketQueue_Retrieve(&( rtpPacketQueue ), 8, NULL);
-    TEST_ASSERT_EQUAL(RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result);
+    result = RtpPacketQueue_Retrieve( &( rtpPacketQueue ), 8, NULL );
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
### Description of changes:

This PR is for adding unit tests to improve coverage, by thoroughly testing the BAD_PARAM scenarios, we ensure that the rtp_pkt_queue.c is fully covered.

The following test cases have been added:
1. `test_RtpPacketQueue_Init_Fail`
2. `test_RtpPacketQueue_Enqueue_Fail`
3. `test_RtpPacketQueue_ForceEnqueue_Fail`
4. `test_RtpPacketQueue_Peek_Fail`
5. `test_RtpPacketQueue_Retrieve_Fail`

### Test Steps

```
git submodule update --init --recursive --checkout test/CMock
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
