### PR TITLE
Add STAP-A support to H264 depacketizer

### DIFF
--- a/codec_packetizers/h264/h264_depacketizer.c
+++ b/codec_packetizers/h264/h264_depacketizer.c
@@ -123,8 +123,7 @@ static H264Result_t DepacketizeAggregationPacket( H264DepacketizerContext_t * pC
         pCtx->curPacketIndex += STAP_A_NALU_SIZE;
 
         /* Is there enough data left in the packet to read the next NALU? */
-        if( ( naluLength > 0 ) &&
-            ( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength ) )
+        if( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
         {
             /* Is there enough space in the output buffer? */
             if( naluLength <= pNalu->naluDataLength)

--- a/codec_packetizers/h264/h264_depacketizer.c
+++ b/codec_packetizers/h264/h264_depacketizer.c
@@ -10,6 +10,9 @@ static void DepacketizeSingleNaluPacket( H264DepacketizerContext_t * pCtx,
 static H264Result_t DepacketizeFragmentationUnitPacket( H264DepacketizerContext_t * pCtx,
                                                         Nalu_t * pNalu );
 
+static H264Result_t DepacketizeAggregationPacket( H264DepacketizerContext_t * pCtx,
+                                                  Nalu_t * pNalu );
+
 /*-----------------------------------------------------------*/
 
 static void DepacketizeSingleNaluPacket( H264DepacketizerContext_t * pCtx,
@@ -93,6 +96,77 @@ static H264Result_t DepacketizeFragmentationUnitPacket( H264DepacketizerContext_
 
 /*-----------------------------------------------------------*/
 
+static H264Result_t DepacketizeAggregationPacket( H264DepacketizerContext_t * pCtx,
+                                                  Nalu_t * pNalu )
+{
+    uint8_t * pCurPacketData;
+    size_t curPacketLength, naluLength;
+    H264Result_t result = H264_RESULT_OK;
+
+    pCurPacketData = pCtx->pPacketsArray[ pCtx->tailIndex ].pPacketData;
+    curPacketLength = pCtx->pPacketsArray[ pCtx->tailIndex ].packetDataLength;
+
+    /* We are just starting to parse a STAP-A packet. Skip the STAP-A header. */
+    if( pCtx->curPacketIndex == 0 )
+    {
+        pCtx->curPacketIndex += STAP_A_HEADER_SIZE;
+    }
+
+    /* Is there enough data left in the packet to read the next NALU size? */
+    if( ( pCtx->curPacketIndex + STAP_A_NALU_SIZE ) <= curPacketLength )
+    {
+        /* Read NALU length. */
+        naluLength = pCurPacketData[ pCtx->curPacketIndex ];
+        naluLength = ( naluLength << 8 ) |
+                     ( pCurPacketData[ pCtx->curPacketIndex + 1 ] );
+
+        pCtx->curPacketIndex += STAP_A_NALU_SIZE;
+
+        /* Is there enough data left in the packet to read the next NALU? */
+        if( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
+        {
+            /* Is there enough space in the output buffer? */
+            if( naluLength <= pNalu->naluDataLength)
+            {
+                memcpy( ( void * ) &( pNalu->pNaluData[ 0 ] ),
+                        ( const void * ) &( pCurPacketData[ pCtx->curPacketIndex ] ),
+                        naluLength );
+            }
+            else
+            {
+                result = H264_RESULT_OUT_OF_MEMORY;
+            }
+
+            /* Update NALU length. */
+            pNalu->naluDataLength = naluLength;
+
+            /* Move to next Nalu in the next call to H264Depacketizer_GetNalu. */
+            pCtx->curPacketIndex += naluLength;
+        }
+        else
+        {
+            result = H264_RESULT_MALFORMED_PACKET;
+
+            /* Still move the curPacketIndex so that we move to the next packet
+             * at the end of this function. */
+            pCtx->curPacketIndex += naluLength;
+        }
+    }
+
+    /* If we do not have enough data left in this packet, move to the next
+     * packet in the next call to H264Depacketizer_GetNalu. */
+    if( ( pCtx->curPacketIndex + STAP_A_NALU_SIZE ) > curPacketLength )
+    {
+        pCtx->curPacketIndex = 0;
+        pCtx->tailIndex += 1;
+        pCtx->packetCount -= 1;
+    }
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
 H264Result_t H264Depacketizer_Init( H264DepacketizerContext_t * pCtx,
                                     H264Packet_t * pPacketsArray,
                                     size_t packetsArrayLength )
@@ -114,6 +188,7 @@ H264Result_t H264Depacketizer_Init( H264DepacketizerContext_t * pCtx,
         pCtx->headIndex = 0;
         pCtx->tailIndex = 0;
         pCtx->packetCount = 0;
+        pCtx->curPacketIndex = 0;
     }
 
     return result;
@@ -188,6 +263,11 @@ H264Result_t H264Depacketizer_GetNalu( H264DepacketizerContext_t * pCtx,
         {
             result = DepacketizeFragmentationUnitPacket( pCtx,
                                                          pNalu );
+        }
+        else if( packetType == STAP_A_PACKET_TYPE )
+        {
+            result = DepacketizeAggregationPacket( pCtx,
+                                                   pNalu );
         }
         else
         {
@@ -303,6 +383,10 @@ H264Result_t H264Depacketizer_GetPacketProperties( const uint8_t * pPacketData,
             {
                 *pProperties |= H264_PACKET_PROPERTY_END_PACKET;
             }
+        }
+        else if( packetType == STAP_A_PACKET_TYPE )
+        {
+            *pProperties = H264_PACKET_PROPERTY_START_PACKET;
         }
         else
         {

--- a/codec_packetizers/h264/h264_depacketizer.c
+++ b/codec_packetizers/h264/h264_depacketizer.c
@@ -123,7 +123,8 @@ static H264Result_t DepacketizeAggregationPacket( H264DepacketizerContext_t * pC
         pCtx->curPacketIndex += STAP_A_NALU_SIZE;
 
         /* Is there enough data left in the packet to read the next NALU? */
-        if( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
+        if( ( naluLength > 0 ) &&
+            ( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength ) )
         {
             /* Is there enough space in the output buffer? */
             if( naluLength <= pNalu->naluDataLength)

--- a/codec_packetizers/h264/include/h264_data_types.h
+++ b/codec_packetizers/h264/include/h264_data_types.h
@@ -86,6 +86,41 @@
 
 /*-----------------------------------------------------------*/
 
+/*
+ * RTP payload format for STAP-A:
+ *
+ *   0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |F|NRI|  type   |                                               |
+ * +-+-+-+-+-+-+-+-+                                               |
+ * |                                                               |
+ * |             one or more aggregation units                     |
+ * |                                                               |
+ * |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                               :...OPTIONAL RTP padding        |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * Structure of each aggregation unit:
+ *
+ *   0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *                 :        NAL unit size          |               |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+               |
+ * |                                                               |
+ * |                           NAL unit                            |
+ * |                                                               |
+ * |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                               :
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+
+#define STAP_A_HEADER_SIZE              1
+#define STAP_A_NALU_SIZE                2
+
+/*-----------------------------------------------------------*/
+
 /* Packet properties, used in H264Depacketizer_GetPacketProperties. */
 #define H264_PACKET_PROPERTY_START_PACKET   ( 1 << 0 )
 #define H264_PACKET_PROPERTY_END_PACKET     ( 1 << 1 )
@@ -105,6 +140,7 @@ typedef enum H264Result
     H264_RESULT_NO_MORE_PACKETS,
     H264_RESULT_NO_MORE_NALUS,
     H264_RESULT_NO_MORE_FRAMES,
+    H264_RESULT_MALFORMED_PACKET,
     H264_RESULT_UNSUPPORTED_PACKET
 } H264Result_t;
 

--- a/codec_packetizers/h264/include/h264_depacketizer.h
+++ b/codec_packetizers/h264/include/h264_depacketizer.h
@@ -10,6 +10,7 @@ typedef struct H264DePacketizerContext
     size_t packetsArrayLength;
     size_t headIndex;
     size_t tailIndex;
+    size_t curPacketIndex;
     size_t packetCount;
 } H264DepacketizerContext_t;
 

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -330,6 +330,90 @@ void test_H264_Depacketizer_GetNalu( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate H264 depacketization happy path to get Nalus for STAP-A packet.
+ */
+void test_H264_Depacketizer_StapAGetNalu( void )
+{
+    H264Result_t result;
+    H264Packet_t pkt;
+    H264DepacketizerContext_t ctx = { 0 };
+    Nalu_t nalu;
+    uint8_t naluBuffer[ MAX_NALU_LENGTH ];
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData[] =
+    {
+        /* STAP-A header. F=0, NRI=0, Type=24. */
+        0x18,
+        /* NALU 1 length. */
+        0x00, 0x05,
+        /* NALU 1 payload. */
+        0xAB, 0xCD, 0xEF, 0x11, 0x22,
+        /* NALU 2 length. */
+        0x00, 0x0A,
+        /* NALU 2 payload. */
+        0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5
+    };
+    uint8_t nalu1Data[] = { 0xAB, 0xCD, 0xEF, 0x11, 0x22 };
+    uint8_t nalu2Data[] = { 0xA1, 0xA2, 0xA3, 0xA4, 0xA5,
+                            0xB1, 0xB2, 0xB3, 0xB4, 0xB5 };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( sizeof( nalu1Data ),
+                       nalu.naluDataLength );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( nalu1Data[ 0 ] ),
+                                   nalu.pNaluData,
+                                   nalu.naluDataLength );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( sizeof( nalu2Data ),
+                       nalu.naluDataLength );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( nalu2Data[ 0 ] ),
+                                   nalu.pNaluData,
+                                   nalu.naluDataLength );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_NO_MORE_NALUS,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Validate H264 depacketization happy path to get frame.
  */
 void test_H264_Depacketizer_GetFrame( void )
@@ -413,6 +497,74 @@ void test_H264_Depacketizer_GetFrame( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate H264 depacketization happy path to get frame for STAP-A packet.
+ */
+void test_H264_Depacketizer_StapAGetFrame( void )
+{
+    H264Result_t result;
+    H264Packet_t pkt;
+    H264DepacketizerContext_t ctx = { 0 };
+    Frame_t frame;
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData[] =
+    {
+        /* STAP-A header. F=0, NRI=0, Type=24. */
+        0x18,
+        /* NALU 1 length. */
+        0x00, 0x05,
+        /* NALU 1 payload. */
+        0xAB, 0xCD, 0xEF, 0x11, 0x22,
+        /* NALU 2 length. */
+        0x00, 0x0A,
+        /* NALU 2 payload. */
+        0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5
+    };
+    uint8_t frameData[] =
+    {
+        /* 4-byte start code. */
+        0x00, 0x00, 0x00, 0x01,
+        /* NALU 1. */
+        0xAB, 0xCD, 0xEF, 0x11, 0x22,
+        /* 4-byte start code. */
+        0x00, 0x00, 0x00, 0x01,
+        /* NALU 2. */
+        0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5
+    };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = MAX_FRAME_LENGTH;
+
+    result = H264Depacketizer_GetFrame( &( ctx ),
+                                        &( frame ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( sizeof( frameData ),
+                       frame.frameDataLength );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( frameData[ 0 ] ),
+                                   frame.pFrameData,
+                                   frame.frameDataLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Validate H264 depacketization happy path to get properties.
  */
 void test_H264_Depacketizer_GetProperties( void )
@@ -420,6 +572,10 @@ void test_H264_Depacketizer_GetProperties( void )
     uint8_t singleNaluPacket[] = { 0x09, 0x10 };
     uint8_t fuAStartPacket[] = { 0x7C, 0x89, 0xAB, 0xCD };
     uint8_t fuAEndPacket[] = { 0x7C, 0x49, 0xAB, 0xCD };
+    uint8_t stapAPacket[] = { 0x18, /* F=0, NRI=0, Type=24. */
+                              0x00, 0x01, 0xAB, /* NALU 1. */
+                              0x00, 0x01, 0xCD  /* NALU 2. */
+                            };
     uint32_t packetProperties;
     H264Result_t result;
     H264Packet_t pkt;
@@ -453,10 +609,16 @@ void test_H264_Depacketizer_GetProperties( void )
                        result );
     TEST_ASSERT_EQUAL( H264_PACKET_PROPERTY_END_PACKET,
                        packetProperties );
+
+    pkt.pPacketData = &( stapAPacket[ 0 ] );
+    pkt.packetDataLength = sizeof( stapAPacket );
+    result = H264Depacketizer_GetPacketProperties( pkt.pPacketData,
+                                                   pkt.packetDataLength,
+                                                   &( packetProperties ) );
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( H264_PACKET_PROPERTY_START_PACKET,
+                       packetProperties );
 }
 
 /*-----------------------------------------------------------*/
-
-
-
-


### PR DESCRIPTION
Description
-------------
Add STAP-A support to H264 depacketizer.

Testing
--------
Added unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
