### PR TITLE
Add remaining unit tests for h264 depacketization

### DIFF
--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -97,11 +97,11 @@ add_custom_target( coverage
     COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
     -P ${MODULE_ROOT_DIR}/test/unit-test/cmock/coverage.cmake
     DEPENDS cmock unity
-    g711
-    opus
-    h264
-    vp8
-    rtp_packet_queue
-    rtp_api
+    g711_utest
+    opus_utest
+    h264_utest
+    vp8_utest
+    rtp_packet_queue_utest
+    rtp_api_utest
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -19,6 +19,12 @@ execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
                          --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
                          --include "*source*"
                          --include "*codec_packetizers*"
+                         --exclude "*source/rtp_endianness.c*"
+                        # The functions in rtp_endianness.c file handle endianness-specific operations for both
+                        # little-endian and big-endian systems. Due to the nature of these operations,
+                        # it is not possible to achieve 100% code coverage as the execution path taken
+                        # depends on the endianness of the target system. Therefore, some branches may
+                        # remain uncovered during testing on a specific endianness.
         )
 file(GLOB files "${CMAKE_BINARY_DIR}/bin/tests/*")
 
@@ -54,6 +60,7 @@ execute_process(
                          --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
                          --include "*source*"
                          --include "*codec_packetizers*"
+                         --exclude "*source/rtp_endianness.c*"
         )
 
 # Combile baseline results (zeros) with the one after running the tests.
@@ -66,6 +73,7 @@ execute_process(
                          --rc lcov_branch_coverage=1
                          --include "*source*"
                          --include "*codec_packetizers*"
+                         --exclude "*source/rtp_endianness.c*"
         )
 execute_process(
             COMMAND genhtml --rc lcov_branch_coverage=1

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -73,7 +73,6 @@ execute_process(
                          --rc lcov_branch_coverage=1
                          --include "*source*"
                          --include "*codec_packetizers*"
-                         --exclude "*source/rtp_endianness.c*"
         )
 execute_process(
             COMMAND genhtml --rc lcov_branch_coverage=1

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -747,7 +747,7 @@ void test_H264_Depacketizer_StapAGetNalu_OutOfMemory( void )
                        result );
 
     nalu.pNaluData = &( naluBuffer[ 0 ] );
-    nalu.naluDataLength = 1; // Set to 1 to simulate out of memory condition
+    nalu.naluDataLength = 1; /* Set to 1 to simulate out of memory condition. */
 
     result = H264Depacketizer_GetNalu( &( ctx ),
                                        &( nalu ) );


### PR DESCRIPTION
*Description of changes:*
This PR adds 3 unit-tests for H264 depacketization covering lines of a static function `DepacketizeAggregationPacket`. 
The coverage for H264 is now 100%.

*Test Steps:*
```
git submodule update --init --recursive --checkout test/CMock
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
