### PR TITLE
Remove ApPacketizationState

### DIFF
--- a/codec_packetizers/h265/h265_packetizer.c
+++ b/codec_packetizers/h265/h265_packetizer.c
@@ -282,9 +282,6 @@ H265Result_t H265Packetizer_Init( H265PacketizerContext_t * pCtx,
         memset( &pCtx->fuPacketizationState,
                 0,
                 sizeof( FuPacketizationState_t ) );
-        memset( &pCtx->apPacketizationState,
-                0,
-                sizeof( ApPacketizationState_t ) );
     }
 
     return result;

--- a/codec_packetizers/h265/include/h265_packetizer.h
+++ b/codec_packetizers/h265/include/h265_packetizer.h
@@ -24,14 +24,6 @@ typedef struct H265AggregationUnitHeader
 } H265AggregationUnitHeader_t;
 
 
-typedef struct ApPacketizationState
-{
-    uint16_t payloadHdr;                 /* Type 48 for AP */
-    size_t totalSize;                    /* Track total AP size */
-    uint8_t naluCount;                   /* Number of NALUs in AP */
-    H265AggregationUnitHeader_t * units; /* Array of aggregation units */
-} ApPacketizationState_t;
-
 /* Main Packetizer Context */
 typedef struct H265PacketizerContext
 {
@@ -44,7 +36,6 @@ typedef struct H265PacketizerContext
     /* Current state */
     H265PacketType_t currentlyProcessingPacket;
     FuPacketizationState_t fuPacketizationState;
-    ApPacketizationState_t apPacketizationState;
 
 } H265PacketizerContext_t;
 


### PR DESCRIPTION
***Description: ***
Removed the ApPacketizationState structure and all associated references. This struct was redundant, as the aggregation logic is now handled entirely through local variables within the relevant functions, making the struct unnecessary. Its removal helps clean up the codebase and avoids confusion regarding state handling during aggregation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
