### PR TITLE
Fix RTP integer overflow and security vulnerabilities

### DIFF
--- a/codec_packetizers/g711/g711_depacketizer.c
+++ b/codec_packetizers/g711/g711_depacketizer.c
@@ -35,7 +35,9 @@ G711Result_t G711Depacketizer_AddPacket( G711DepacketizerContext_t * pCtx,
     G711Result_t result = G711_RESULT_OK;
 
     if( ( pCtx == NULL ) ||
-        ( pPacket == NULL ) )
+        ( pPacket == NULL ) ||
+        ( pPacket->pPacketData == NULL ) ||
+        ( pPacket->packetDataLength == 0 ) )
     {
         result = G711_RESULT_BAD_PARAM;
     }
@@ -79,7 +81,9 @@ G711Result_t G711Depacketizer_GetFrame( G711DepacketizerContext_t * pCtx,
     {
         pPacket = &( pCtx->pPacketsArray[ i ] );
 
-        if( ( pFrame->frameDataLength - currentFrameDataIndex ) >= pPacket->packetDataLength )
+        if( ( pPacket->pPacketData != NULL ) &&
+            ( currentFrameDataIndex < pFrame->frameDataLength ) &&
+            ( ( pFrame->frameDataLength - currentFrameDataIndex ) >= pPacket->packetDataLength ) )
         {
             memcpy( ( void * ) &( pFrame->pFrameData[ currentFrameDataIndex ] ),
                     ( const void * ) &( pPacket->pPacketData[ 0 ] ),

--- a/codec_packetizers/g711/g711_packetizer.c
+++ b/codec_packetizers/g711/g711_packetizer.c
@@ -42,7 +42,7 @@ G711Result_t G711Packetizer_GetPacket( G711PacketizerContext_t * pCtx,
         ( pPacket->pPacketData == NULL ) ||
         ( pPacket->packetDataLength == 0 ) ||
         ( pCtx->frame.pFrameData == NULL ) ||
-        ( pCtx->curFrameDataIndex >= pCtx->frame.frameDataLength ) )
+        ( pCtx->curFrameDataIndex > pCtx->frame.frameDataLength ) )
     {
         result = G711_RESULT_BAD_PARAM;
     }
@@ -66,14 +66,6 @@ G711Result_t G711Packetizer_GetPacket( G711PacketizerContext_t * pCtx,
 
         pPacket->packetDataLength = frameDataLengthToSend;
         pCtx->curFrameDataIndex += frameDataLengthToSend;
-
-        /* Check for logic error - curFrameDataIndex should never exceed frameDataLength */
-        if( pCtx->curFrameDataIndex > pCtx->frame.frameDataLength )
-        {
-            pCtx->curFrameDataIndex = pCtx->frame.frameDataLength;
-            result = G711_RESULT_NO_MORE_PACKETS;
-        }
-
     }
 
     return result;

--- a/codec_packetizers/g711/g711_packetizer.c
+++ b/codec_packetizers/g711/g711_packetizer.c
@@ -39,14 +39,16 @@ G711Result_t G711Packetizer_GetPacket( G711PacketizerContext_t * pCtx,
 
     if( ( pCtx == NULL ) ||
         ( pPacket == NULL ) ||
-        ( pPacket->packetDataLength == 0 ) )
+        ( pPacket->pPacketData == NULL ) ||
+        ( pPacket->packetDataLength == 0 ) ||
+        ( pCtx->frame.pFrameData == NULL ) )
     {
         result = G711_RESULT_BAD_PARAM;
     }
 
     if( result == G711_RESULT_OK )
     {
-        if( pCtx->curFrameDataIndex == pCtx->frame.frameDataLength )
+        if( pCtx->curFrameDataIndex >= pCtx->frame.frameDataLength )
         {
             result = G711_RESULT_NO_MORE_PACKETS;
         }
@@ -63,6 +65,14 @@ G711Result_t G711Packetizer_GetPacket( G711PacketizerContext_t * pCtx,
 
         pPacket->packetDataLength = frameDataLengthToSend;
         pCtx->curFrameDataIndex += frameDataLengthToSend;
+
+        /* Check for logic error - curFrameDataIndex should never exceed frameDataLength */
+        if( pCtx->curFrameDataIndex > pCtx->frame.frameDataLength )
+        {
+            pCtx->curFrameDataIndex = pCtx->frame.frameDataLength;
+            result = G711_RESULT_NO_MORE_PACKETS;
+        }
+
     }
 
     return result;

--- a/codec_packetizers/g711/g711_packetizer.c
+++ b/codec_packetizers/g711/g711_packetizer.c
@@ -41,14 +41,15 @@ G711Result_t G711Packetizer_GetPacket( G711PacketizerContext_t * pCtx,
         ( pPacket == NULL ) ||
         ( pPacket->pPacketData == NULL ) ||
         ( pPacket->packetDataLength == 0 ) ||
-        ( pCtx->frame.pFrameData == NULL ) )
+        ( pCtx->frame.pFrameData == NULL ) ||
+        ( pCtx->curFrameDataIndex >= pCtx->frame.frameDataLength ) )
     {
         result = G711_RESULT_BAD_PARAM;
     }
 
     if( result == G711_RESULT_OK )
     {
-        if( pCtx->curFrameDataIndex >= pCtx->frame.frameDataLength )
+        if( pCtx->curFrameDataIndex == pCtx->frame.frameDataLength )
         {
             result = G711_RESULT_NO_MORE_PACKETS;
         }

--- a/codec_packetizers/h264/h264_depacketizer.c
+++ b/codec_packetizers/h264/h264_depacketizer.c
@@ -224,7 +224,9 @@ H264Result_t H264Depacketizer_AddPacket( H264DepacketizerContext_t * pCtx,
     H264Result_t result = H264_RESULT_OK;
 
     if( ( pCtx == NULL ) ||
-        ( pPacket == NULL ) )
+        ( pPacket == NULL ) ||
+        ( pPacket->pPacketData == NULL ) ||
+        ( pPacket->packetDataLength == 0 ) )
     {
         result = H264_RESULT_BAD_PARAM;
     }
@@ -257,7 +259,8 @@ H264Result_t H264Depacketizer_GetNalu( H264DepacketizerContext_t * pCtx,
     uint8_t packetType;
 
     if( ( pCtx == NULL ) ||
-        ( pNalu == NULL ) )
+        ( pNalu == NULL ) ||
+        ( pNalu->pNaluData == NULL ) )
     {
         result = H264_RESULT_BAD_PARAM;
     }
@@ -267,6 +270,15 @@ H264Result_t H264Depacketizer_GetNalu( H264DepacketizerContext_t * pCtx,
         if( pCtx->packetCount == 0 )
         {
             result = H264_RESULT_NO_MORE_NALUS;
+        }
+    }
+
+    if( result == H264_RESULT_OK )
+    {
+        if( ( pCtx->tailIndex >= pCtx->packetsArrayLength ) ||
+            ( pCtx->pPacketsArray[ pCtx->tailIndex ].pPacketData == NULL ) )
+        {
+            result = H264_RESULT_BAD_PARAM;
         }
     }
 

--- a/codec_packetizers/h264/h264_depacketizer.c
+++ b/codec_packetizers/h264/h264_depacketizer.c
@@ -278,8 +278,8 @@ H264Result_t H264Depacketizer_GetNalu( H264DepacketizerContext_t * pCtx,
         if( ( packetType >= SINGLE_NALU_PACKET_TYPE_START ) &&
             ( packetType <= SINGLE_NALU_PACKET_TYPE_END ) )
         {
-            DepacketizeSingleNaluPacket( pCtx,
-                                         pNalu );
+            result = DepacketizeSingleNaluPacket( pCtx,
+                                                  pNalu );
         }
         else if( packetType == FU_A_PACKET_TYPE )
         {

--- a/codec_packetizers/h264/h264_packetizer.c
+++ b/codec_packetizers/h264/h264_packetizer.c
@@ -314,6 +314,14 @@ H264Result_t H264Packetizer_GetPacket( H264PacketizerContext_t * pCtx,
 
     if( result == H264_RESULT_OK )
     {
+        if( pCtx->pNaluArray[ pCtx->tailIndex ].pNaluData == NULL )
+        {
+            result = H264_RESULT_BAD_PARAM;
+        }
+    }
+
+    if( result == H264_RESULT_OK )
+    {
         /* Are we in the middle of packetizing fragments of a NALU? */
         if( pCtx->currentlyProcessingPacket == H264_FU_A_PACKET )
         {

--- a/codec_packetizers/h265/h265_depacketizer.c
+++ b/codec_packetizers/h265/h265_depacketizer.c
@@ -133,7 +133,8 @@ static H265Result_t DepacketizeAggregationPacket( H265DepacketizerContext_t * pC
     }
 
     /* Is there enough data left in the packet to read the next NALU size? */
-    if( ( pCtx->curPacketIndex + AP_NALU_LENGTH_FIELD_SIZE ) <= curPacketLength )
+    if( ( SIZE_MAX - AP_NALU_LENGTH_FIELD_SIZE ) >= pCtx->curPacketIndex &&
+        ( pCtx->curPacketIndex + AP_NALU_LENGTH_FIELD_SIZE ) <= curPacketLength )
     {
         /* Read NALU length. */
         naluLength = pCurPacketData[ pCtx->curPacketIndex ];
@@ -143,7 +144,8 @@ static H265Result_t DepacketizeAggregationPacket( H265DepacketizerContext_t * pC
         pCtx->curPacketIndex += AP_NALU_LENGTH_FIELD_SIZE;
 
         /* Is there enough data left in the packet to read the next NALU? */
-        if( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
+        if( ( SIZE_MAX - naluLength ) >= pCtx->curPacketIndex &&
+            ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
         {
             /* Is there enough space in the output buffer? */
             if( naluLength <= pNalu->naluDataLength )
@@ -161,7 +163,14 @@ static H265Result_t DepacketizeAggregationPacket( H265DepacketizerContext_t * pC
             pNalu->naluDataLength = naluLength;
 
             /* Move to next Nalu in the next call to H265Depacketizer_GetNalu. */
-            pCtx->curPacketIndex += naluLength;
+            if( ( SIZE_MAX - pCtx->curPacketIndex ) >= naluLength )
+            {
+                pCtx->curPacketIndex += naluLength;
+            }
+            else
+            {
+                result = H265_RESULT_MALFORMED_PACKET;
+            }
         }
         else
         {
@@ -169,7 +178,14 @@ static H265Result_t DepacketizeAggregationPacket( H265DepacketizerContext_t * pC
 
             /* Still move the curPacketIndex so that we move to the next packet
              * at the end of this function. */
-            pCtx->curPacketIndex += naluLength;
+            if( ( SIZE_MAX - naluLength ) >= pCtx->curPacketIndex )
+            {
+                pCtx->curPacketIndex += naluLength;
+            }
+            else
+            {
+                pCtx->curPacketIndex = curPacketLength;
+            }
         }
     }
     else
@@ -226,14 +242,17 @@ H265Result_t H265Depacketizer_AddPacket( H265DepacketizerContext_t * pCtx,
     H265Result_t result = H265_RESULT_OK;
 
     if( ( pCtx == NULL ) ||
-        ( pPacket == NULL ) )
+        ( pPacket == NULL ) ||
+        ( pPacket->pPacketData == NULL ) ||
+        ( pPacket->packetDataLength == 0 ) )
     {
         result = H265_RESULT_BAD_PARAM;
     }
 
     if( result == H265_RESULT_OK )
     {
-        if( pCtx->packetCount >= pCtx->packetsArrayLength )
+        if( ( pCtx->packetCount >= pCtx->packetsArrayLength ) ||
+            ( pCtx->headIndex >= pCtx->packetsArrayLength ) )
         {
             result = H265_RESULT_OUT_OF_MEMORY;
         }
@@ -269,6 +288,17 @@ H265Result_t H265Depacketizer_GetNalu( H265DepacketizerContext_t * pCtx,
         if( pCtx->packetCount == 0 )
         {
             result = H265_RESULT_NO_MORE_NALUS;
+        }
+    }
+
+    if( result == H265_RESULT_OK )
+    {
+        if( ( pNalu->pNaluData == NULL ) ||
+            ( pCtx->tailIndex >= pCtx->packetsArrayLength ) ||
+            ( pCtx->pPacketsArray[ pCtx->tailIndex ].pPacketData == NULL ) ||
+            ( pCtx->pPacketsArray[ pCtx->tailIndex ].packetDataLength == 0 ) )
+        {
+            result = H265_RESULT_BAD_PARAM;
         }
     }
 

--- a/codec_packetizers/h265/h265_depacketizer.c
+++ b/codec_packetizers/h265/h265_depacketizer.c
@@ -144,8 +144,7 @@ static H265Result_t DepacketizeAggregationPacket( H265DepacketizerContext_t * pC
         pCtx->curPacketIndex += AP_NALU_LENGTH_FIELD_SIZE;
 
         /* Is there enough data left in the packet to read the next NALU? */
-        if( ( SIZE_MAX - naluLength ) >= pCtx->curPacketIndex &&
-            ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
+        if( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
         {
             /* Is there enough space in the output buffer? */
             if( naluLength <= pNalu->naluDataLength )
@@ -163,14 +162,7 @@ static H265Result_t DepacketizeAggregationPacket( H265DepacketizerContext_t * pC
             pNalu->naluDataLength = naluLength;
 
             /* Move to next Nalu in the next call to H265Depacketizer_GetNalu. */
-            if( ( SIZE_MAX - pCtx->curPacketIndex ) >= naluLength )
-            {
-                pCtx->curPacketIndex += naluLength;
-            }
-            else
-            {
-                result = H265_RESULT_MALFORMED_PACKET;
-            }
+            pCtx->curPacketIndex += naluLength;
         }
         else
         {
@@ -178,14 +170,7 @@ static H265Result_t DepacketizeAggregationPacket( H265DepacketizerContext_t * pC
 
             /* Still move the curPacketIndex so that we move to the next packet
              * at the end of this function. */
-            if( ( SIZE_MAX - naluLength ) >= pCtx->curPacketIndex )
-            {
-                pCtx->curPacketIndex += naluLength;
-            }
-            else
-            {
-                pCtx->curPacketIndex = curPacketLength;
-            }
+            pCtx->curPacketIndex += naluLength;
         }
     }
     else

--- a/codec_packetizers/h265/h265_packetizer.c
+++ b/codec_packetizers/h265/h265_packetizer.c
@@ -158,11 +158,26 @@ static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
     /* Aggregate all the NAL units in the packet. */
     for( i = 0; i < nalusToAggregate; i++ )
     {
+        if( ( pCtx->tailIndex + i ) >= pCtx->naluArrayLength )
+        {
+            break;
+        }
         pNaluData = pCtx->pNaluArray[ pCtx->tailIndex + i ].pNaluData;
         naluSize = pCtx->pNaluArray[ pCtx->tailIndex + i ].naluDataLength;
 
+        if( ( pNaluData == NULL ) || ( naluSize < NALU_HEADER_SIZE ) )
+        {
+            break;
+        }
+
         temporalId = ( pNaluData[ 1 ] & NALU_HEADER_TID_MASK ) >> NALU_HEADER_TID_LOCATION;
         minTemporalId = H265_MIN( minTemporalId, temporalId );
+
+        /* Check if we have enough space in the packet buffer. */
+        if( ( packetWriteIndex + 2 + naluSize ) > pPacket->packetDataLength )
+        {
+            break;
+        }
 
         /* Update F bit in the payload header. */
         pPacket->pPacketData[ 0 ] |= ( pNaluData[ 0 ] & NALU_HEADER_F_MASK );
@@ -182,8 +197,12 @@ static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
     /* Write TID in the payload header. */
     pPacket->pPacketData[ 1 ] |= ( minTemporalId << NALU_HEADER_TID_LOCATION );
 
-    pCtx->tailIndex += nalusToAggregate;
-    pCtx->naluCount -= nalusToAggregate;
+    /* Update context state with bounds checking. */
+    if( nalusToAggregate <= pCtx->naluCount )
+    {
+        pCtx->tailIndex += nalusToAggregate;
+        pCtx->naluCount -= nalusToAggregate;
+    }
 
     pPacket->packetDataLength = packetWriteIndex;
 }
@@ -356,11 +375,18 @@ H265Result_t H265Packetizer_AddNalu( H265PacketizerContext_t * pCtx,
 
     if( result == H265_RESULT_OK )
     {
-        pCtx->pNaluArray[ pCtx->headIndex ].pNaluData = pNalu->pNaluData;
-        pCtx->pNaluArray[ pCtx->headIndex ].naluDataLength = pNalu->naluDataLength;
+        if( pCtx->headIndex < pCtx->naluArrayLength )
+        {
+            pCtx->pNaluArray[ pCtx->headIndex ].pNaluData = pNalu->pNaluData;
+            pCtx->pNaluArray[ pCtx->headIndex ].naluDataLength = pNalu->naluDataLength;
 
-        pCtx->headIndex += 1;
-        pCtx->naluCount += 1;
+            pCtx->headIndex += 1;
+            pCtx->naluCount += 1;
+        }
+        else
+        {
+            result = H265_RESULT_OUT_OF_MEMORY;
+        }
     }
 
     return result;
@@ -411,6 +437,10 @@ H265Result_t H265Packetizer_GetPacket( H265PacketizerContext_t * pCtx,
                 aggregatePacketSize = AP_HEADER_SIZE;
                 for( i = 0; i < pCtx->naluCount; i++ )
                 {
+                    if( ( pCtx->tailIndex + i ) >= pCtx->naluArrayLength )
+                    {
+                        break;
+                    }
                     naluSize = pCtx->pNaluArray[ pCtx->tailIndex + i ].naluDataLength;
 
                     /* Can we fit in this NAL unit? */

--- a/codec_packetizers/h265/h265_packetizer.c
+++ b/codec_packetizers/h265/h265_packetizer.c
@@ -125,7 +125,7 @@ static H265Result_t PacketizeFragmentationUnitPacket( H265PacketizerContext_t * 
                     ( const void * ) &( pNaluData[ pCtx->fuPacketizationState.naluDataIndex ] ),
                     naluDataLengthToSend );
         }
-        
+
         if( result == H265_RESULT_OK )
         {
             pPacket->packetDataLength = naluDataLengthToSend + FU_PAYLOAD_HEADER_SIZE + FU_HEADER_SIZE;

--- a/codec_packetizers/h265/h265_packetizer.c
+++ b/codec_packetizers/h265/h265_packetizer.c
@@ -12,9 +12,9 @@ static void PacketizeSingleNaluPacket( H265PacketizerContext_t * pCtx,
 static H265Result_t PacketizeFragmentationUnitPacket( H265PacketizerContext_t * pCtx,
                                                       H265Packet_t * pPacket );
 
-static H265Result_t PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
-                                                size_t nalusToAggregate,
-                                                H265Packet_t * pPacket );
+static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
+                                        size_t nalusToAggregate,
+                                        H265Packet_t * pPacket );
 
 /*-----------------------------------------------------------*/
 
@@ -119,7 +119,7 @@ static H265Result_t PacketizeFragmentationUnitPacket( H265PacketizerContext_t * 
         {
             result = H265_RESULT_MALFORMED_PACKET;
         }
-        else if( naluDataLengthToSend > 0 )
+        else
         {
             memcpy( ( void * ) &( pPacket->pPacketData[ FU_PAYLOAD_HEADER_SIZE + FU_HEADER_SIZE ] ),
                     ( const void * ) &( pNaluData[ pCtx->fuPacketizationState.naluDataIndex ] ),
@@ -153,11 +153,10 @@ static H265Result_t PacketizeFragmentationUnitPacket( H265PacketizerContext_t * 
 
 /*-----------------------------------------------------------*/
 
-static H265Result_t PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
-                                                size_t nalusToAggregate,
-                                                H265Packet_t * pPacket )
+static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
+                                        size_t nalusToAggregate,
+                                        H265Packet_t * pPacket )
 {
-    H265Result_t result = H265_RESULT_OK;
     size_t i, packetWriteIndex = 0, naluSize;
     uint8_t * pNaluData;
     uint8_t temporalId, minTemporalId = 0xFF;
@@ -170,29 +169,11 @@ static H265Result_t PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
     /* Aggregate all the NAL units in the packet. */
     for( i = 0; i < nalusToAggregate; i++ )
     {
-        if( ( pCtx->tailIndex + i ) >= pCtx->naluArrayLength )
-        {
-            result = H265_RESULT_OUT_OF_MEMORY;
-            break;
-        }
         pNaluData = pCtx->pNaluArray[ pCtx->tailIndex + i ].pNaluData;
         naluSize = pCtx->pNaluArray[ pCtx->tailIndex + i ].naluDataLength;
 
-        if( ( pNaluData == NULL ) || ( naluSize < NALU_HEADER_SIZE ) )
-        {
-            result = H265_RESULT_BAD_PARAM;
-            break;
-        }
-
         temporalId = ( pNaluData[ 1 ] & NALU_HEADER_TID_MASK ) >> NALU_HEADER_TID_LOCATION;
         minTemporalId = H265_MIN( minTemporalId, temporalId );
-
-        /* Check if we have enough space in the packet buffer. */
-        if( ( packetWriteIndex + 2 + naluSize ) > pPacket->packetDataLength )
-        {
-            result = H265_RESULT_OUT_OF_MEMORY;
-            break;
-        }
 
         /* Update F bit in the payload header. */
         pPacket->pPacketData[ 0 ] |= ( pNaluData[ 0 ] & NALU_HEADER_F_MASK );
@@ -209,22 +190,14 @@ static H265Result_t PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
         packetWriteIndex += naluSize;
     }
 
-    if( result == H265_RESULT_OK )
-    {
-        /* Write TID in the payload header. */
-        pPacket->pPacketData[ 1 ] |= ( minTemporalId << NALU_HEADER_TID_LOCATION );
+    /* Write TID in the payload header. */
+    pPacket->pPacketData[ 1 ] |= ( minTemporalId << NALU_HEADER_TID_LOCATION );
 
-        /* Update context state with bounds checking. */
-        if( nalusToAggregate <= pCtx->naluCount )
-        {
-            pCtx->tailIndex += nalusToAggregate;
-            pCtx->naluCount -= nalusToAggregate;
-        }
+    /* Update context state. */
+    pCtx->tailIndex += nalusToAggregate;
+    pCtx->naluCount -= nalusToAggregate;
 
-        pPacket->packetDataLength = packetWriteIndex;
-    }
-
-    return result;
+    pPacket->packetDataLength = packetWriteIndex;
 }
 
 /*-----------------------------------------------------------*/
@@ -494,17 +467,20 @@ H265Result_t H265Packetizer_GetPacket( H265PacketizerContext_t * pCtx,
                 }
 
                 /* If we can aggregate more than one NAL units, use Aggregation Packet. */
-                if( nalusToAggregate > 1 )
+                if( result == H265_RESULT_OK )
                 {
-                    result = PacketizeAggregationPacket( pCtx,
-                                                         nalusToAggregate,
-                                                         pPacket );
-                }
-                else
-                {
-                    /* Otherwise, use Single NAL Unit Packet. */
-                    PacketizeSingleNaluPacket( pCtx,
-                                               pPacket );
+                    if( nalusToAggregate > 1 )
+                    {
+                        PacketizeAggregationPacket( pCtx,
+                                                   nalusToAggregate,
+                                                   pPacket );
+                    }
+                    else
+                    {
+                        /* Otherwise, use Single NAL Unit Packet. */
+                        PacketizeSingleNaluPacket( pCtx,
+                                                pPacket );
+                    }
                 }
             }
             else

--- a/codec_packetizers/h265/h265_packetizer.c
+++ b/codec_packetizers/h265/h265_packetizer.c
@@ -12,9 +12,9 @@ static void PacketizeSingleNaluPacket( H265PacketizerContext_t * pCtx,
 static H265Result_t PacketizeFragmentationUnitPacket( H265PacketizerContext_t * pCtx,
                                                       H265Packet_t * pPacket );
 
-static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
-                                        size_t nalusToAggregate,
-                                        H265Packet_t * pPacket );
+static H265Result_t PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
+                                                size_t nalusToAggregate,
+                                                H265Packet_t * pPacket );
 
 /*-----------------------------------------------------------*/
 
@@ -153,10 +153,11 @@ static H265Result_t PacketizeFragmentationUnitPacket( H265PacketizerContext_t * 
 
 /*-----------------------------------------------------------*/
 
-static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
-                                        size_t nalusToAggregate,
-                                        H265Packet_t * pPacket )
+static H265Result_t PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
+                                                size_t nalusToAggregate,
+                                                H265Packet_t * pPacket )
 {
+    H265Result_t result = H265_RESULT_OK;
     size_t i, packetWriteIndex = 0, naluSize;
     uint8_t * pNaluData;
     uint8_t temporalId, minTemporalId = 0xFF;
@@ -171,6 +172,7 @@ static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
     {
         if( ( pCtx->tailIndex + i ) >= pCtx->naluArrayLength )
         {
+            result = H265_RESULT_OUT_OF_MEMORY;
             break;
         }
         pNaluData = pCtx->pNaluArray[ pCtx->tailIndex + i ].pNaluData;
@@ -178,6 +180,7 @@ static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
 
         if( ( pNaluData == NULL ) || ( naluSize < NALU_HEADER_SIZE ) )
         {
+            result = H265_RESULT_BAD_PARAM;
             break;
         }
 
@@ -187,6 +190,7 @@ static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
         /* Check if we have enough space in the packet buffer. */
         if( ( packetWriteIndex + 2 + naluSize ) > pPacket->packetDataLength )
         {
+            result = H265_RESULT_OUT_OF_MEMORY;
             break;
         }
 
@@ -205,17 +209,22 @@ static void PacketizeAggregationPacket( H265PacketizerContext_t * pCtx,
         packetWriteIndex += naluSize;
     }
 
-    /* Write TID in the payload header. */
-    pPacket->pPacketData[ 1 ] |= ( minTemporalId << NALU_HEADER_TID_LOCATION );
-
-    /* Update context state with bounds checking. */
-    if( nalusToAggregate <= pCtx->naluCount )
+    if( result == H265_RESULT_OK )
     {
-        pCtx->tailIndex += nalusToAggregate;
-        pCtx->naluCount -= nalusToAggregate;
+        /* Write TID in the payload header. */
+        pPacket->pPacketData[ 1 ] |= ( minTemporalId << NALU_HEADER_TID_LOCATION );
+
+        /* Update context state with bounds checking. */
+        if( nalusToAggregate <= pCtx->naluCount )
+        {
+            pCtx->tailIndex += nalusToAggregate;
+            pCtx->naluCount -= nalusToAggregate;
+        }
+
+        pPacket->packetDataLength = packetWriteIndex;
     }
 
-    pPacket->packetDataLength = packetWriteIndex;
+    return result;
 }
 
 /*-----------------------------------------------------------*/
@@ -436,14 +445,13 @@ H265Result_t H265Packetizer_GetPacket( H265PacketizerContext_t * pCtx,
         {
             result = H265_RESULT_OUT_OF_MEMORY;
         }
-    }
-
-    /* Validate NALU data pointer */
-    if( result == H265_RESULT_OK )
-    {
-        if( pCtx->pNaluArray[ pCtx->tailIndex ].pNaluData == NULL )
+        else if( pCtx->pNaluArray[ pCtx->tailIndex ].pNaluData == NULL )
         {
             result = H265_RESULT_BAD_PARAM;
+        }
+        else if( pCtx->pNaluArray[ pCtx->tailIndex ].naluDataLength == 0 )
+        {
+            result = H265_RESULT_MALFORMED_PACKET;
         }
     }
 
@@ -468,6 +476,7 @@ H265Result_t H265Packetizer_GetPacket( H265PacketizerContext_t * pCtx,
                 {
                     if( ( pCtx->tailIndex + i ) >= pCtx->naluArrayLength )
                     {
+                        result = H265_RESULT_OUT_OF_MEMORY;
                         break;
                     }
                     naluSize = pCtx->pNaluArray[ pCtx->tailIndex + i ].naluDataLength;
@@ -487,9 +496,9 @@ H265Result_t H265Packetizer_GetPacket( H265PacketizerContext_t * pCtx,
                 /* If we can aggregate more than one NAL units, use Aggregation Packet. */
                 if( nalusToAggregate > 1 )
                 {
-                    PacketizeAggregationPacket( pCtx,
-                                                nalusToAggregate,
-                                                pPacket );
+                    result = PacketizeAggregationPacket( pCtx,
+                                                         nalusToAggregate,
+                                                         pPacket );
                 }
                 else
                 {

--- a/codec_packetizers/h265/h265_packetizer.c
+++ b/codec_packetizers/h265/h265_packetizer.c
@@ -115,25 +115,36 @@ static H265Result_t PacketizeFragmentationUnitPacket( H265PacketizerContext_t * 
         pPacket->pPacketData[ FU_HEADER_OFFSET ] = fuHeader;
 
         /* Write NALU data. */
-        memcpy( ( void * ) &( pPacket->pPacketData[ FU_PAYLOAD_HEADER_SIZE + FU_HEADER_SIZE ] ),
-                ( const void * ) &( pNaluData[ pCtx->fuPacketizationState.naluDataIndex ] ),
-                naluDataLengthToSend );
-        pPacket->packetDataLength = naluDataLengthToSend + FU_PAYLOAD_HEADER_SIZE + FU_HEADER_SIZE;
-
-        pCtx->fuPacketizationState.naluDataIndex += naluDataLengthToSend;
-        pCtx->fuPacketizationState.remainingNaluLength -= naluDataLengthToSend;
-
-        if( pCtx->fuPacketizationState.remainingNaluLength == 0 )
+        if( ( pCtx->fuPacketizationState.naluDataIndex + naluDataLengthToSend ) > pCtx->pNaluArray[ pCtx->tailIndex ].naluDataLength )
         {
-            /* Reset state. */
-            memset( &( pCtx->fuPacketizationState ),
-                    0,
-                    sizeof( FuPacketizationState_t ) );
-            pCtx->currentlyProcessingPacket = H265_PACKET_NONE;
+            result = H265_RESULT_MALFORMED_PACKET;
+        }
+        else if( naluDataLengthToSend > 0 )
+        {
+            memcpy( ( void * ) &( pPacket->pPacketData[ FU_PAYLOAD_HEADER_SIZE + FU_HEADER_SIZE ] ),
+                    ( const void * ) &( pNaluData[ pCtx->fuPacketizationState.naluDataIndex ] ),
+                    naluDataLengthToSend );
+        }
+        
+        if( result == H265_RESULT_OK )
+        {
+            pPacket->packetDataLength = naluDataLengthToSend + FU_PAYLOAD_HEADER_SIZE + FU_HEADER_SIZE;
 
-            /* Move to the next NALU in the next call to H265Packetizer_GetPacket. */
-            pCtx->tailIndex += 1;
-            pCtx->naluCount -= 1;
+            pCtx->fuPacketizationState.naluDataIndex += naluDataLengthToSend;
+            pCtx->fuPacketizationState.remainingNaluLength -= naluDataLengthToSend;
+
+            if( pCtx->fuPacketizationState.remainingNaluLength == 0 )
+            {
+                /* Reset state. */
+                memset( &( pCtx->fuPacketizationState ),
+                        0,
+                        sizeof( FuPacketizationState_t ) );
+                pCtx->currentlyProcessingPacket = H265_PACKET_NONE;
+
+                /* Move to the next NALU in the next call to H265Packetizer_GetPacket. */
+                pCtx->tailIndex += 1;
+                pCtx->naluCount -= 1;
+            }
         }
     }
 
@@ -415,6 +426,24 @@ H265Result_t H265Packetizer_GetPacket( H265PacketizerContext_t * pCtx,
         if( pCtx->naluCount == 0 )
         {
             result = H265_RESULT_NO_MORE_PACKETS;
+        }
+    }
+
+    /* Validate tailIndex bounds */
+    if( result == H265_RESULT_OK )
+    {
+        if( pCtx->tailIndex >= pCtx->naluArrayLength )
+        {
+            result = H265_RESULT_OUT_OF_MEMORY;
+        }
+    }
+
+    /* Validate NALU data pointer */
+    if( result == H265_RESULT_OK )
+    {
+        if( pCtx->pNaluArray[ pCtx->tailIndex ].pNaluData == NULL )
+        {
+            result = H265_RESULT_BAD_PARAM;
         }
     }
 

--- a/codec_packetizers/opus/opus_depacketizer.c
+++ b/codec_packetizers/opus/opus_depacketizer.c
@@ -118,6 +118,8 @@ OpusResult_t OpusDepacketizer_GetPacketProperties( const uint8_t * pPacketData,
 {
     OpusResult_t result = OPUS_RESULT_OK;
 
+    ( void ) packetDataLength;
+
     if( ( pPacketData == NULL ) ||
         ( pProperties == NULL ) ||
         ( packetDataLength == 0 ) )

--- a/codec_packetizers/opus/opus_packetizer.c
+++ b/codec_packetizers/opus/opus_packetizer.c
@@ -39,6 +39,7 @@ OpusResult_t OpusPacketizer_GetPacket( OpusPacketizerContext_t * pCtx,
 
     if( ( pCtx == NULL ) ||
         ( pPacket == NULL ) ||
+        ( pPacket->pPacketData == NULL ) ||
         ( pPacket->packetDataLength == 0 ) )
     {
         result = OPUS_RESULT_BAD_PARAM;

--- a/codec_packetizers/vp8/vp8_depacketizer.c
+++ b/codec_packetizers/vp8/vp8_depacketizer.c
@@ -168,27 +168,35 @@ VP8Result_t VP8Depacketizer_GetFrame( VP8DepacketizerContext_t * pCtx,
     {
         pPacket = &( pCtx->pPacketsArray[ i ] );
 
-        payloadDescLength = ReadPayloadDescriptor( pPacket,
-                                                   pFrame );
-
-        if( pPacket->packetDataLength > payloadDescLength )
+        if( ( pPacket->packetDataLength < 1 ) ||
+            ( pPacket->packetDataLength < 2 &&
+              ( pPacket->pPacketData[ VP8_PAYLOAD_DESC_HEADER_OFFSET ] & VP8_PAYLOAD_DESC_X_BITMASK ) != 0 ) )
         {
-            if( ( pFrame->frameDataLength - curFrameDataIndex ) >= ( pPacket->packetDataLength - payloadDescLength ) )
-            {
-                memcpy( ( void * ) &( pFrame->pFrameData[ curFrameDataIndex ] ),
-                        ( const void * ) &( pPacket->pPacketData[ payloadDescLength ] ),
-                        pPacket->packetDataLength - payloadDescLength );
-
-                curFrameDataIndex += ( pPacket->packetDataLength - payloadDescLength );
-            }
-            else
-            {
-                result = VP8_RESULT_OUT_OF_MEMORY;
-            }
+            result = VP8_MALFORMED_PACKET;
         }
         else
         {
-            result = VP8_MALFORMED_PACKET;
+            payloadDescLength = ReadPayloadDescriptor( pPacket, pFrame );
+
+            if( pPacket->packetDataLength > payloadDescLength )
+            {
+                if( ( pFrame->frameDataLength - curFrameDataIndex ) >= ( pPacket->packetDataLength - payloadDescLength ) )
+                {
+                    memcpy( ( void * ) &( pFrame->pFrameData[ curFrameDataIndex ] ),
+                            ( const void * ) &( pPacket->pPacketData[ payloadDescLength ] ),
+                            pPacket->packetDataLength - payloadDescLength );
+
+                    curFrameDataIndex += ( pPacket->packetDataLength - payloadDescLength );
+                }
+                else
+                {
+                    result = VP8_RESULT_OUT_OF_MEMORY;
+                }
+            }
+            else
+            {
+                result = VP8_MALFORMED_PACKET;
+            }
         }
     }
 

--- a/codec_packetizers/vp8/vp8_depacketizer.c
+++ b/codec_packetizers/vp8/vp8_depacketizer.c
@@ -14,80 +14,123 @@ static size_t ReadPayloadDescriptor( const VP8Packet_t * pPacket,
 {
     size_t curIndex = 0;
     uint8_t extensions;
+    int isValid = 1;
+
+    /* Basic packet validation */
+    if( pPacket->packetDataLength < 1 )
+    {
+        isValid = 0;
+    }
+    else if( pPacket->packetDataLength < 2 &&
+             ( pPacket->pPacketData[ VP8_PAYLOAD_DESC_HEADER_OFFSET ] & VP8_PAYLOAD_DESC_X_BITMASK ) != 0 )
+    {
+        isValid = 0;
+    }
 
     pFrame->frameProperties = 0;
-    if( ( pPacket->pPacketData[ VP8_PAYLOAD_DESC_HEADER_OFFSET ] & VP8_PAYLOAD_DESC_N_BITMASK ) != 0 )
+    if( isValid && ( pPacket->pPacketData[ VP8_PAYLOAD_DESC_HEADER_OFFSET ] & VP8_PAYLOAD_DESC_N_BITMASK ) != 0 )
     {
         pFrame->frameProperties |= VP8_FRAME_PROP_NON_REF_FRAME;
     }
 
-    if( ( pPacket->pPacketData[ VP8_PAYLOAD_DESC_HEADER_OFFSET ] & VP8_PAYLOAD_DESC_X_BITMASK ) != 0 )
+    if( isValid && ( pPacket->pPacketData[ VP8_PAYLOAD_DESC_HEADER_OFFSET ] & VP8_PAYLOAD_DESC_X_BITMASK ) != 0 )
     {
         extensions = pPacket->pPacketData[ VP8_PAYLOAD_DESC_EXT_OFFSET ];
 
         /* Location to read the next extension. */
         curIndex += 2;
 
-        if( ( extensions & VP8_PAYLOAD_DESC_EXT_I_BITMASK ) != 0 )
+        if( ( extensions & VP8_PAYLOAD_DESC_EXT_I_BITMASK ) != 0 &&
+              isValid )
         {
-            pFrame->frameProperties |= VP8_FRAME_PROP_PICTURE_ID_PRESENT;
-
-            if( ( pPacket->pPacketData[ curIndex ] & VP8_PAYLOAD_DESC_EXT_M_BITMASK ) != 0 )
+            if( curIndex >= pPacket->packetDataLength )
             {
-                pFrame->pictureId = ( ( pPacket->pPacketData[ curIndex ] & ~VP8_PAYLOAD_DESC_EXT_M_BITMASK ) << 8 );
-                pFrame->pictureId |= pPacket->pPacketData[ curIndex + 1 ];
-                curIndex += 2;
+                isValid = 0;
             }
             else
             {
-                pFrame->pictureId = pPacket->pPacketData[ curIndex ];
+                pFrame->frameProperties |= VP8_FRAME_PROP_PICTURE_ID_PRESENT;
+
+                if( ( pPacket->pPacketData[ curIndex ] & VP8_PAYLOAD_DESC_EXT_M_BITMASK ) != 0 )
+                {
+                    if( curIndex + 1 >= pPacket->packetDataLength )
+                    {
+                        isValid = 0;
+                    }
+                    else
+                    {
+                        pFrame->pictureId = ( ( pPacket->pPacketData[ curIndex ] & ~VP8_PAYLOAD_DESC_EXT_M_BITMASK ) << 8 );
+                        pFrame->pictureId |= pPacket->pPacketData[ curIndex + 1 ];
+                        curIndex += 2;
+                    }
+                }
+                else
+                {
+                    pFrame->pictureId = pPacket->pPacketData[ curIndex ];
+                    curIndex += 1;
+                }
+            }
+        }
+
+        if( ( extensions & VP8_PAYLOAD_DESC_EXT_L_BITMASK ) != 0 &&
+              isValid )
+        {
+            if( curIndex >= pPacket->packetDataLength )
+            {
+                isValid = 0;
+            }
+            else
+            {
+                pFrame->frameProperties |= VP8_FRAME_PROP_TL0PICIDX_PRESENT;
+
+                pFrame->tl0PicIndex = pPacket->pPacketData[ curIndex ];
                 curIndex += 1;
             }
         }
 
-        if( ( extensions & VP8_PAYLOAD_DESC_EXT_L_BITMASK ) != 0 )
+        if( ( ( extensions & VP8_PAYLOAD_DESC_EXT_T_BITMASK ) != 0 ||
+              ( extensions & VP8_PAYLOAD_DESC_EXT_K_BITMASK ) != 0 ) &&
+                isValid )
         {
-            pFrame->frameProperties |= VP8_FRAME_PROP_TL0PICIDX_PRESENT;
-
-            pFrame->tl0PicIndex = pPacket->pPacketData[ curIndex ];
-            curIndex += 1;
-        }
-
-        if( ( ( extensions & VP8_PAYLOAD_DESC_EXT_T_BITMASK ) != 0 ) ||
-            ( ( extensions & VP8_PAYLOAD_DESC_EXT_K_BITMASK ) != 0 ) )
-        {
-            if( ( extensions & VP8_PAYLOAD_DESC_EXT_T_BITMASK ) != 0 )
+            if( curIndex >= pPacket->packetDataLength )
             {
-                pFrame->frameProperties |= VP8_FRAME_PROP_TID_PRESENT;
-
-                pFrame->tid = ( pPacket->pPacketData[ curIndex ] &
-                                VP8_PAYLOAD_DESC_EXT_TID_BITMASK ) >>
-                              VP8_PAYLOAD_DESC_EXT_TID_LOCATION;
+                isValid = 0;
             }
-
-            if( ( extensions & VP8_PAYLOAD_DESC_EXT_K_BITMASK ) != 0 )
+            else
             {
-                pFrame->frameProperties |= VP8_FRAME_PROP_KEYIDX_PRESENT;
+                if( ( extensions & VP8_PAYLOAD_DESC_EXT_T_BITMASK ) != 0 )
+                {
+                    pFrame->frameProperties |= VP8_FRAME_PROP_TID_PRESENT;
 
-                pFrame->keyIndex = ( pPacket->pPacketData[ curIndex ] &
-                                     VP8_PAYLOAD_DESC_EXT_KEYIDX_BITMASK ) >>
-                                   VP8_PAYLOAD_DESC_EXT_KEYIDX_LOCATION;
+                    pFrame->tid = ( pPacket->pPacketData[ curIndex ] &
+                                    VP8_PAYLOAD_DESC_EXT_TID_BITMASK ) >>
+                                  VP8_PAYLOAD_DESC_EXT_TID_LOCATION;
+                }
+
+                if( ( extensions & VP8_PAYLOAD_DESC_EXT_K_BITMASK ) != 0 )
+                {
+                    pFrame->frameProperties |= VP8_FRAME_PROP_KEYIDX_PRESENT;
+
+                    pFrame->keyIndex = ( pPacket->pPacketData[ curIndex ] &
+                                         VP8_PAYLOAD_DESC_EXT_KEYIDX_BITMASK ) >>
+                                       VP8_PAYLOAD_DESC_EXT_KEYIDX_LOCATION;
+                }
+
+                if( ( pPacket->pPacketData[ curIndex ] & VP8_PAYLOAD_DESC_EXT_Y_BITMASK ) != 0 )
+                {
+                    pFrame->frameProperties |= VP8_FRAME_PROP_DEPENDS_ON_BASE_ONLY;
+                }
+
+                curIndex += 1;
             }
-
-            if( ( pPacket->pPacketData[ curIndex ] & VP8_PAYLOAD_DESC_EXT_Y_BITMASK ) != 0 )
-            {
-                pFrame->frameProperties |= VP8_FRAME_PROP_DEPENDS_ON_BASE_ONLY;
-            }
-
-            curIndex += 1;
         }
     }
-    else
+    else if( isValid )
     {
         curIndex += 1;
     }
 
-    return curIndex;
+    return isValid ? curIndex : 0;
 }
 
 /*-----------------------------------------------------------*/
@@ -168,17 +211,12 @@ VP8Result_t VP8Depacketizer_GetFrame( VP8DepacketizerContext_t * pCtx,
     {
         pPacket = &( pCtx->pPacketsArray[ i ] );
 
-        if( ( pPacket->packetDataLength < 1 ) ||
-            ( pPacket->packetDataLength < 2 &&
-              ( pPacket->pPacketData[ VP8_PAYLOAD_DESC_HEADER_OFFSET ] & VP8_PAYLOAD_DESC_X_BITMASK ) != 0 ) )
-        {
-            result = VP8_MALFORMED_PACKET;
-        }
-        else
-        {
-            payloadDescLength = ReadPayloadDescriptor( pPacket, pFrame );
+        payloadDescLength = ReadPayloadDescriptor( pPacket, pFrame );
 
-            if( pPacket->packetDataLength > payloadDescLength )
+            /* ReadPayloadDescriptor should return at least 1 (mandatory VP8 header),
+             * 0 indicates malformed packet due to bounds violation during extension parsing */
+            if( payloadDescLength != 0 &&
+                pPacket->packetDataLength > payloadDescLength )
             {
                 if( ( pFrame->frameDataLength - curFrameDataIndex ) >= ( pPacket->packetDataLength - payloadDescLength ) )
                 {

--- a/codec_packetizers/vp8/vp8_depacketizer.c
+++ b/codec_packetizers/vp8/vp8_depacketizer.c
@@ -213,28 +213,27 @@ VP8Result_t VP8Depacketizer_GetFrame( VP8DepacketizerContext_t * pCtx,
 
         payloadDescLength = ReadPayloadDescriptor( pPacket, pFrame );
 
-            /* ReadPayloadDescriptor should return at least 1 (mandatory VP8 header),
-             * 0 indicates malformed packet due to bounds violation during extension parsing */
-            if( payloadDescLength != 0 &&
-                pPacket->packetDataLength > payloadDescLength )
+        /* ReadPayloadDescriptor should return at least 1 (mandatory VP8 header),
+         * 0 indicates malformed packet due to bounds violation during extension parsing */
+        if( payloadDescLength != 0 &&
+            pPacket->packetDataLength > payloadDescLength )
+        {
+            if( ( pFrame->frameDataLength - curFrameDataIndex ) >= ( pPacket->packetDataLength - payloadDescLength ) )
             {
-                if( ( pFrame->frameDataLength - curFrameDataIndex ) >= ( pPacket->packetDataLength - payloadDescLength ) )
-                {
-                    memcpy( ( void * ) &( pFrame->pFrameData[ curFrameDataIndex ] ),
-                            ( const void * ) &( pPacket->pPacketData[ payloadDescLength ] ),
-                            pPacket->packetDataLength - payloadDescLength );
+                memcpy( ( void * ) &( pFrame->pFrameData[ curFrameDataIndex ] ),
+                        ( const void * ) &( pPacket->pPacketData[ payloadDescLength ] ),
+                        pPacket->packetDataLength - payloadDescLength );
 
-                    curFrameDataIndex += ( pPacket->packetDataLength - payloadDescLength );
-                }
-                else
-                {
-                    result = VP8_RESULT_OUT_OF_MEMORY;
-                }
+                curFrameDataIndex += ( pPacket->packetDataLength - payloadDescLength );
             }
             else
             {
-                result = VP8_MALFORMED_PACKET;
+                result = VP8_RESULT_OUT_OF_MEMORY;
             }
+        }
+        else
+        {
+            result = VP8_MALFORMED_PACKET;
         }
     }
 

--- a/codec_packetizers/vp8/vp8_depacketizer.c
+++ b/codec_packetizers/vp8/vp8_depacketizer.c
@@ -40,8 +40,7 @@ static size_t ReadPayloadDescriptor( const VP8Packet_t * pPacket,
         /* Location to read the next extension. */
         curIndex += 2;
 
-        if( ( extensions & VP8_PAYLOAD_DESC_EXT_I_BITMASK ) != 0 &&
-              isValid )
+        if( ( extensions & VP8_PAYLOAD_DESC_EXT_I_BITMASK ) != 0 )
         {
             if( curIndex >= pPacket->packetDataLength )
             {

--- a/codec_packetizers/vp8/vp8_packetizer.c
+++ b/codec_packetizers/vp8/vp8_packetizer.c
@@ -146,8 +146,7 @@ VP8Result_t VP8Packetizer_GetPacket( VP8PacketizerContext_t * pCtx,
 
     if( result == VP8_RESULT_OK )
     {
-        if( ( pPacket->packetDataLength > pCtx->payloadDescLength ) &&
-            ( pCtx->frameDataLength > pCtx->curFrameDataIndex ) )
+        if( pPacket->packetDataLength > pCtx->payloadDescLength )
         {
             memcpy( ( void * ) &( pPacket->pPacketData[ 0 ] ),
                     ( const void * ) &( pCtx->payloadDesc[ 0 ] ),

--- a/codec_packetizers/vp8/vp8_packetizer.c
+++ b/codec_packetizers/vp8/vp8_packetizer.c
@@ -129,7 +129,9 @@ VP8Result_t VP8Packetizer_GetPacket( VP8PacketizerContext_t * pCtx,
     size_t frameDataLengthToSend;
 
     if( ( pCtx == NULL ) ||
-        ( pPacket == NULL ) )
+        ( pPacket == NULL ) ||
+        ( pPacket->pPacketData == NULL ) ||
+        ( pPacket->packetDataLength == 0 ) )
     {
         result = VP8_RESULT_BAD_PARAM;
     }
@@ -144,7 +146,8 @@ VP8Result_t VP8Packetizer_GetPacket( VP8PacketizerContext_t * pCtx,
 
     if( result == VP8_RESULT_OK )
     {
-        if( pPacket->packetDataLength > pCtx->payloadDescLength )
+        if( ( pPacket->packetDataLength > pCtx->payloadDescLength ) &&
+            ( pCtx->frameDataLength > pCtx->curFrameDataIndex ) )
         {
             memcpy( ( void * ) &( pPacket->pPacketData[ 0 ] ),
                     ( const void * ) &( pCtx->payloadDesc[ 0 ] ),

--- a/source/rtp_api.c
+++ b/source/rtp_api.c
@@ -91,17 +91,7 @@ static RtpResult_t CalculateSerializedPacketLength( const RtpPacket_t * pRtpPack
 
         if( ( pRtpPacket->header.flags & RTP_HEADER_FLAG_EXTENSION ) != 0 )
         {
-            size_t extensionSize = ( pRtpPacket->header.extension.extensionPayloadLength * sizeof( uint32_t ) );
-
-            /* Check for overflow in extension calculation */
-            if( ( SIZE_MAX - headerLength - 4 ) < extensionSize )
-            {
-                result = RTP_RESULT_MALFORMED_PACKET;
-            }
-            else
-            {
-                headerLength = headerLength + 4 + extensionSize;
-            }
+            headerLength += 4 + ( pRtpPacket->header.extension.extensionPayloadLength * sizeof( uint32_t ) );
         }
     }
 
@@ -427,24 +417,17 @@ RtpResult_t Rtp_DeSerialize( RtpContext_t * pCtx,
                 /* From RFC3550, section 5.1: The last octet of the padding
                  * contains a count of how many padding octets should be
                  * ignored, including itself. */
-                if( pRtpPacket->payloadLength > 0 )
-                {
-                    numPaddingOctets = pRtpPacket->pPayload[ pRtpPacket->payloadLength - 1 ];
+                numPaddingOctets = pRtpPacket->pPayload[ pRtpPacket->payloadLength - 1 ];
 
-                    if( ( numPaddingOctets > 0 ) &&
-                        ( numPaddingOctets <= pRtpPacket->payloadLength ) )
-                    {
-                        pRtpPacket->payloadLength -= numPaddingOctets;
-                    }
-                    else
-                    {
-                        /* The number of padding octets must be > 0 and cannot be
-                         * larger than the payload length. */
-                        result = RTP_RESULT_MALFORMED_PACKET;
-                    }
+                if( ( numPaddingOctets > 0 ) &&
+                    ( numPaddingOctets <= pRtpPacket->payloadLength ) )
+                {
+                    pRtpPacket->payloadLength -= numPaddingOctets;
                 }
                 else
                 {
+                    /* The number of padding octets must be > 0 and cannot be
+                     * larger than the payload length. */
                     result = RTP_RESULT_MALFORMED_PACKET;
                 }
             }

--- a/source/rtp_api.c
+++ b/source/rtp_api.c
@@ -75,9 +75,20 @@ static RtpResult_t CalculateSerializedPacketLength( const RtpPacket_t * pRtpPack
 static RtpResult_t CalculateSerializedPacketLength( const RtpPacket_t * pRtpPacket,
                                                     size_t * pLength )
 {
-    size_t headerLength = RTP_HEADER_MIN_LENGTH +
-                          ( pRtpPacket->header.csrcCount * sizeof( uint32_t ) );
     RtpResult_t result = RTP_RESULT_OK;
+    size_t headerLength;
+
+    /* Validate CSRC count - RTP spec limits to 4 bits (0-15) */
+    if( pRtpPacket->header.csrcCount > 15 )
+    {
+        result = RTP_RESULT_MALFORMED_PACKET;
+    }
+
+    if( result == RTP_RESULT_OK )
+    {
+        headerLength = RTP_HEADER_MIN_LENGTH +
+                       ( pRtpPacket->header.csrcCount * sizeof( uint32_t ) );
+    }
 
     if( ( pRtpPacket->header.flags & RTP_HEADER_FLAG_EXTENSION ) != 0 )
     {

--- a/source/rtp_api.c
+++ b/source/rtp_api.c
@@ -456,12 +456,6 @@ RtpResult_t Rtp_DeSerialize( RtpContext_t * pCtx,
         }
     }
 
-    /* Clear output structure on error to prevent information disclosure */
-    if( result != RTP_RESULT_OK )
-    {
-        memset( pRtpPacket, 0, sizeof( RtpPacket_t ) );
-    }
-
     return result;
 }
 

--- a/source/rtp_api.c
+++ b/source/rtp_api.c
@@ -67,23 +67,47 @@
 
 /*-----------------------------------------------------------*/
 
-static size_t CalculateSerializedPacketLength( const RtpPacket_t * pRtpPacket );
+static RtpResult_t CalculateSerializedPacketLength( const RtpPacket_t * pRtpPacket,
+                                                    size_t * pLength );
 
 /*-----------------------------------------------------------*/
 
-static size_t CalculateSerializedPacketLength( const RtpPacket_t * pRtpPacket )
+static RtpResult_t CalculateSerializedPacketLength( const RtpPacket_t * pRtpPacket,
+                                                    size_t * pLength )
 {
     size_t headerLength = RTP_HEADER_MIN_LENGTH +
                           ( pRtpPacket->header.csrcCount * sizeof( uint32_t ) );
+    RtpResult_t result = RTP_RESULT_OK;
 
     if( ( pRtpPacket->header.flags & RTP_HEADER_FLAG_EXTENSION ) != 0 )
     {
-        headerLength = headerLength +
-                       4 + /* Extension header. */
-                       ( pRtpPacket->header.extension.extensionPayloadLength * sizeof( uint32_t ) );
+        size_t extensionSize = ( pRtpPacket->header.extension.extensionPayloadLength * sizeof( uint32_t ) );
+
+        /* Check for overflow in extension calculation */
+        if( ( SIZE_MAX - headerLength - 4 ) < extensionSize )
+        {
+            result = RTP_RESULT_MALFORMED_PACKET;
+        }
+        else
+        {
+            headerLength = headerLength + 4 + extensionSize;
+        }
     }
 
-    return headerLength + pRtpPacket->payloadLength;
+    if( result == RTP_RESULT_OK )
+    {
+        /* Check for overflow in final addition */
+        if( ( SIZE_MAX - headerLength ) < pRtpPacket->payloadLength )
+        {
+            result = RTP_RESULT_MALFORMED_PACKET;
+        }
+        else
+        {
+            *pLength = headerLength + pRtpPacket->payloadLength;
+        }
+    }
+
+    return result;
 }
 
 /*-----------------------------------------------------------*/
@@ -126,8 +150,11 @@ RtpResult_t Rtp_Serialize( RtpContext_t * pCtx,
 
     if( result == RTP_RESULT_OK )
     {
-        serializedPacketLength = CalculateSerializedPacketLength( pRtpPacket );
+        result = CalculateSerializedPacketLength( pRtpPacket, &serializedPacketLength );
+    }
 
+    if( result == RTP_RESULT_OK )
+    {
         if( ( pBuffer != NULL ) &&
             ( *pLength < serializedPacketLength ) )
         {
@@ -222,10 +249,11 @@ RtpResult_t Rtp_Serialize( RtpContext_t * pCtx,
                  * ignored, including itself. */
                 numPaddingOctets = pRtpPacket->pPayload[ pRtpPacket->payloadLength - 1 ];
 
-                if( numPaddingOctets > pRtpPacket->payloadLength )
+                if( ( numPaddingOctets == 0 ) ||
+                    ( numPaddingOctets > pRtpPacket->payloadLength ) )
                 {
-                    /* The number of padding octets cannot be larger than the
-                     * payload length. */
+                    /* The number of padding octets must be > 0 and cannot be
+                     * larger than the payload length. */
                     result = RTP_RESULT_MALFORMED_PACKET;
                 }
             }
@@ -305,7 +333,7 @@ RtpResult_t Rtp_DeSerialize( RtpContext_t * pCtx,
         if( pRtpPacket->header.csrcCount > 0 )
         {
             /* Is there enough data to read CSRCs? */
-            if( ( currentIndex + ( pRtpPacket->header.csrcCount * sizeof( uint32_t ) ) ) <= serializedPacketLength )
+            if( ( pRtpPacket->header.csrcCount * sizeof( uint32_t ) ) <= ( serializedPacketLength - currentIndex ) )
             {
                 pRtpPacket->header.pCsrc = ( uint32_t * ) &( pSerializedPacket[ currentIndex ] );
 
@@ -335,7 +363,7 @@ RtpResult_t Rtp_DeSerialize( RtpContext_t * pCtx,
             pRtpPacket->header.flags |= RTP_HEADER_FLAG_EXTENSION;
 
             /* Is there enough data to read extension header? */
-            if( ( currentIndex + sizeof( uint32_t ) ) <= serializedPacketLength )
+            if( sizeof( uint32_t ) <= ( serializedPacketLength - currentIndex ) )
             {
                 extensionHeader = RTP_READ_UINT32( &( pSerializedPacket[ currentIndex ] ) );
                 currentIndex += 4;
@@ -355,9 +383,8 @@ RtpResult_t Rtp_DeSerialize( RtpContext_t * pCtx,
             if( result == RTP_RESULT_OK )
             {
                 /* Is there enough data to read extension payload? */
-                if( ( currentIndex +
-                      ( pRtpPacket->header.extension.extensionPayloadLength *
-                        sizeof( uint32_t ) ) ) <= serializedPacketLength )
+                if( ( pRtpPacket->header.extension.extensionPayloadLength *
+                      sizeof( uint32_t ) ) <= ( serializedPacketLength - currentIndex ) )
                 {
                     pRtpPacket->header.extension.pExtensionPayload = ( uint32_t * ) &( pSerializedPacket[ currentIndex ] );
 
@@ -389,16 +416,24 @@ RtpResult_t Rtp_DeSerialize( RtpContext_t * pCtx,
                 /* From RFC3550, section 5.1: The last octet of the padding
                  * contains a count of how many padding octets should be
                  * ignored, including itself. */
-                numPaddingOctets = pRtpPacket->pPayload[ pRtpPacket->payloadLength - 1 ];
-
-                if( numPaddingOctets <= pRtpPacket->payloadLength )
+                if( pRtpPacket->payloadLength > 0 )
                 {
-                    pRtpPacket->payloadLength -= numPaddingOctets;
+                    numPaddingOctets = pRtpPacket->pPayload[ pRtpPacket->payloadLength - 1 ];
+
+                    if( ( numPaddingOctets > 0 ) &&
+                        ( numPaddingOctets <= pRtpPacket->payloadLength ) )
+                    {
+                        pRtpPacket->payloadLength -= numPaddingOctets;
+                    }
+                    else
+                    {
+                        /* The number of padding octets must be > 0 and cannot be
+                         * larger than the payload length. */
+                        result = RTP_RESULT_MALFORMED_PACKET;
+                    }
                 }
                 else
                 {
-                    /* The number of padding octets cannot be larger than the
-                     * payload length. */
                     result = RTP_RESULT_MALFORMED_PACKET;
                 }
             }
@@ -408,6 +443,12 @@ RtpResult_t Rtp_DeSerialize( RtpContext_t * pCtx,
             pRtpPacket->pPayload = NULL;
             pRtpPacket->payloadLength = 0;
         }
+    }
+
+    /* Clear output structure on error to prevent information disclosure */
+    if( result != RTP_RESULT_OK )
+    {
+        memset( pRtpPacket, 0, sizeof( RtpPacket_t ) );
     }
 
     return result;

--- a/source/rtp_api.c
+++ b/source/rtp_api.c
@@ -88,20 +88,20 @@ static RtpResult_t CalculateSerializedPacketLength( const RtpPacket_t * pRtpPack
     {
         headerLength = RTP_HEADER_MIN_LENGTH +
                        ( pRtpPacket->header.csrcCount * sizeof( uint32_t ) );
-    }
 
-    if( ( pRtpPacket->header.flags & RTP_HEADER_FLAG_EXTENSION ) != 0 )
-    {
-        size_t extensionSize = ( pRtpPacket->header.extension.extensionPayloadLength * sizeof( uint32_t ) );
+        if( ( pRtpPacket->header.flags & RTP_HEADER_FLAG_EXTENSION ) != 0 )
+        {
+            size_t extensionSize = ( pRtpPacket->header.extension.extensionPayloadLength * sizeof( uint32_t ) );
 
-        /* Check for overflow in extension calculation */
-        if( ( SIZE_MAX - headerLength - 4 ) < extensionSize )
-        {
-            result = RTP_RESULT_MALFORMED_PACKET;
-        }
-        else
-        {
-            headerLength = headerLength + 4 + extensionSize;
+            /* Check for overflow in extension calculation */
+            if( ( SIZE_MAX - headerLength - 4 ) < extensionSize )
+            {
+                result = RTP_RESULT_MALFORMED_PACKET;
+            }
+            else
+            {
+                headerLength = headerLength + 4 + extensionSize;
+            }
         }
     }
 

--- a/source/rtp_pkt_queue.c
+++ b/source/rtp_pkt_queue.c
@@ -43,13 +43,21 @@ RtpPacketQueueResult_t RtpPacketQueue_Init( RtpPacketQueue_t * pQueue,
         pQueue->pRtpPacketInfoArray = pRtpPacketInfoArray;
         pQueue->rtpPacketInfoArrayLength = rtpPacketInfoArrayLength;
 
-        memset( pQueue->pRtpPacketInfoArray,
-                0,
-                sizeof( RtpPacketInfo_t ) * pQueue->rtpPacketInfoArrayLength );
+        /* Check for overflow in memset size calculation */
+        if( ( SIZE_MAX / sizeof( RtpPacketInfo_t ) ) < pQueue->rtpPacketInfoArrayLength )
+        {
+            result = RTP_PACKET_QUEUE_RESULT_BAD_PARAM;
+        }
+        else
+        {
+            memset( pQueue->pRtpPacketInfoArray,
+                    0,
+                    sizeof( RtpPacketInfo_t ) * pQueue->rtpPacketInfoArrayLength );
 
-        pQueue->readIndex = 0;
-        pQueue->writeIndex = 0;
-        pQueue->packetCount = 0;
+            pQueue->readIndex = 0;
+            pQueue->writeIndex = 0;
+            pQueue->packetCount = 0;
+        }
     }
 
     return result;

--- a/source/rtp_pkt_queue.c
+++ b/source/rtp_pkt_queue.c
@@ -43,21 +43,13 @@ RtpPacketQueueResult_t RtpPacketQueue_Init( RtpPacketQueue_t * pQueue,
         pQueue->pRtpPacketInfoArray = pRtpPacketInfoArray;
         pQueue->rtpPacketInfoArrayLength = rtpPacketInfoArrayLength;
 
-        /* Check for overflow in memset size calculation */
-        if( ( SIZE_MAX / sizeof( RtpPacketInfo_t ) ) < pQueue->rtpPacketInfoArrayLength )
-        {
-            result = RTP_PACKET_QUEUE_RESULT_BAD_PARAM;
-        }
-        else
-        {
-            memset( pQueue->pRtpPacketInfoArray,
-                    0,
-                    sizeof( RtpPacketInfo_t ) * pQueue->rtpPacketInfoArrayLength );
+        memset( pQueue->pRtpPacketInfoArray,
+                0,
+                sizeof( RtpPacketInfo_t ) * pQueue->rtpPacketInfoArrayLength );
 
-            pQueue->readIndex = 0;
-            pQueue->writeIndex = 0;
-            pQueue->packetCount = 0;
-        }
+        pQueue->readIndex = 0;
+        pQueue->writeIndex = 0;
+        pQueue->packetCount = 0;
     }
 
     return result;

--- a/test/unit-test/g711/g711_utest.c
+++ b/test/unit-test/g711/g711_utest.c
@@ -162,6 +162,22 @@ void test_G711_Packetizer_GetPacket_BadParams( void )
                                        &( pkt ) );
     TEST_ASSERT_EQUAL( G711_RESULT_BAD_PARAM,
                        result );
+
+    pkt.pPacketData = NULL;
+    pkt.packetDataLength = PACKETIZATION_BUFFER_LENGTH;
+    result = G711Packetizer_GetPacket( &( ctx ), &( pkt ) );
+    TEST_ASSERT_EQUAL( G711_RESULT_BAD_PARAM, result );
+
+    ctx.frame.pFrameData = NULL;
+    pkt.pPacketData = &( packetizationBuffer[ 0 ] );
+    result = G711Packetizer_GetPacket( &( ctx ), &( pkt ) );
+    TEST_ASSERT_EQUAL( G711_RESULT_BAD_PARAM, result );
+
+    ctx.frame.pFrameData = &( packetizationBuffer[ 0 ] );
+    ctx.curFrameDataIndex = 2;
+    ctx.frame.frameDataLength = 0;
+    result = G711Packetizer_GetPacket( &( ctx ), &( pkt ) );
+    TEST_ASSERT_EQUAL( G711_RESULT_BAD_PARAM, result );
 }
 
 /* ==============================  Test Cases for Depacketization ============================== */
@@ -303,6 +319,20 @@ void test_G711_Depacketizer_AddPacket_BadParams( void )
                                          NULL );
     TEST_ASSERT_EQUAL( G711_RESULT_BAD_PARAM,
                        result );
+
+    pkt.pPacketData = NULL;
+    pkt.packetDataLength = sizeof( packetData );
+    result = G711Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    TEST_ASSERT_EQUAL( G711_RESULT_BAD_PARAM,
+                       result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = 0;
+    result = G711Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    TEST_ASSERT_EQUAL( G711_RESULT_BAD_PARAM,
+                       result );
 }
 
 /*-----------------------------------------------------------*/
@@ -422,6 +452,33 @@ void test_G711_Depacketizer_GetFrame_OutOfMemory( void )
                        result );
 }
 
+/**
+ * @brief Validate G711_Depacketizer_GetFrame when packet size exceeds remaining frame space.
+ */
+void test_G711_Depacketizer_GetFrame_CurrentIndexEqualsFrameLength( void )
+{
+    G711Result_t result;
+    G711DepacketizerContext_t ctx = { 0 };
+    G711Packet_t packetsArray[ MAX_PACKET_IN_A_FRAME ];
+    G711Frame_t frame;
+    uint8_t packetData[] = { 0x01, 0x02, 0x03 };
+
+    result = G711Depacketizer_Init( &( ctx ), &( packetsArray[ 0 ] ), MAX_PACKET_IN_A_FRAME );
+    TEST_ASSERT_EQUAL( G711_RESULT_OK, result );
+
+    ctx.pPacketsArray[ 0 ].pPacketData = packetData;
+    ctx.pPacketsArray[ 0 ].packetDataLength = 1;
+    ctx.pPacketsArray[ 1 ].pPacketData = packetData;
+    ctx.pPacketsArray[ 1 ].packetDataLength = 3;
+    ctx.packetCount = 2;
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = 2;
+    result = G711Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( G711_RESULT_OUT_OF_MEMORY, result );
+}
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -455,6 +512,60 @@ void test_G711_Depacketizer_GetPacketProperties_BadParams( void )
                                                    NULL );
     TEST_ASSERT_EQUAL( G711_RESULT_BAD_PARAM,
                        result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate G711_Depacketizer_GetFrame when currentFrameDataIndex equals frameDataLength.
+ */
+void test_G711_Depacketizer_GetFrame_IndexEqualsLength( void )
+{
+    G711Result_t result;
+    G711DepacketizerContext_t ctx = { 0 };
+    G711Packet_t packetsArray[ MAX_PACKET_IN_A_FRAME ];
+    G711Frame_t frame;
+    uint8_t packetData[] = { 0x01, 0x02 };
+
+    result = G711Depacketizer_Init( &( ctx ), &( packetsArray[ 0 ] ), MAX_PACKET_IN_A_FRAME );
+    TEST_ASSERT_EQUAL( G711_RESULT_OK, result );
+
+    ctx.pPacketsArray[ 0 ].pPacketData = packetData;
+    ctx.pPacketsArray[ 0 ].packetDataLength = 2;
+    ctx.pPacketsArray[ 1 ].pPacketData = packetData;
+    ctx.pPacketsArray[ 1 ].packetDataLength = 1;
+    ctx.packetCount = 2;
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = 2;
+    result = G711Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( G711_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Validate G711_Depacketizer_GetFrame with NULL packet data in loop.
+ */
+void test_G711_Depacketizer_GetFrame_NullPacketInLoop( void )
+{
+    G711Result_t result;
+    G711DepacketizerContext_t ctx = { 0 };
+    G711Packet_t packetsArray[ MAX_PACKET_IN_A_FRAME ];
+    G711Frame_t frame;
+
+    result = G711Depacketizer_Init( &( ctx ), &( packetsArray[ 0 ] ), MAX_PACKET_IN_A_FRAME );
+    TEST_ASSERT_EQUAL( G711_RESULT_OK, result );
+
+    ctx.pPacketsArray[ 0 ].pPacketData = NULL;
+    ctx.pPacketsArray[ 0 ].packetDataLength = 1;
+    ctx.packetCount = 1;
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = MAX_FRAME_LENGTH;
+    result = G711Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( G711_RESULT_OUT_OF_MEMORY, result );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -596,6 +596,21 @@ void test_H264_Packetizer_GetPacket_BadParams( void )
 
     TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
                        result );
+
+    /* Test NULL pNaluData in array */
+    Nalu_t nalusArray[ 1 ] = { { NULL, 10 } };
+    ctx.pNaluArray = nalusArray;
+    ctx.naluArrayLength = 1;
+    ctx.naluCount = 1;
+    ctx.tailIndex = 0;
+    pkt.pPacketData = &( pktBuffer[ 0 ] );
+    pkt.packetDataLength = MAX_H264_PACKET_LENGTH;
+
+    result = H264Packetizer_GetPacket( &( ctx ),
+                                       &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
+                       result );
 }
 
 /* ==============================  Test Cases for Depacketization ============================== */
@@ -1758,6 +1773,22 @@ void test_H264_Depacketizer_AddPacket_BadParams( void )
 
     TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
                        result );
+
+    pkt.pPacketData = NULL;
+    pkt.packetDataLength = sizeof( packetData1 );
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
+                       result );
+
+    pkt.pPacketData = &( packetData1[ 0 ] );
+    pkt.packetDataLength = 0;
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
+                       result );
 }
 
 /*-----------------------------------------------------------*/
@@ -1806,6 +1837,38 @@ void test_H264_Depacketizer_GetNalu_BadParams( void )
 
     result = H264Depacketizer_GetNalu( &( ctx ),
                                        NULL );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
+                       result );
+
+    nalu.pNaluData = NULL;
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
+                       result );
+
+    /* Test NULL pPacketData */
+    H264Packet_t h264Packet = { NULL, 10 };
+    ctx.pPacketsArray = &h264Packet;
+    ctx.packetsArrayLength = 1;
+    ctx.packetCount = 1;
+    ctx.tailIndex = 0;
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
+                       result );
+
+    /* Test invalid tailIndex */
+    ctx.tailIndex = 1;
+    ctx.packetCount = 1;
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
 
     TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
                        result );
@@ -2028,6 +2091,75 @@ void test_H264_Depacketizer_GetFrame_OutOfMemory( void )
                                         &( frame ) );
 
     TEST_ASSERT_EQUAL( H264_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test H264Depacketizer_GetNalu with NULL pNaluData
+ */
+void test_H264_Depacketizer_GetNalu_NullNaluData( void )
+{
+    H264Result_t result;
+    H264DepacketizerContext_t ctx = { 0 };
+    Nalu_t nalu;
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData[] = { 0x09, 0x10 };
+    H264Packet_t pkt = {
+        .pPacketData = packetData,
+        .packetDataLength = sizeof( packetData )
+    };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    packetsArray,
+                                    MAX_PACKETS_IN_A_FRAME );
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = NULL;
+    nalu.naluDataLength = 100;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H264Depacketizer_GetNalu with invalid tailIndex
+ */
+void test_H264_Depacketizer_GetNalu_InvalidTailIndex( void )
+{
+    H264Result_t result;
+    H264DepacketizerContext_t ctx = { 0 };
+    Nalu_t nalu;
+    uint8_t naluBuffer[ 100 ];
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    packetsArray,
+                                    MAX_PACKETS_IN_A_FRAME );
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = naluBuffer;
+    nalu.naluDataLength = sizeof( naluBuffer );
+
+    ctx.packetCount = 1;
+    ctx.tailIndex = MAX_PACKETS_IN_A_FRAME;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_BAD_PARAM,
                        result );
 }
 

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -1831,6 +1831,7 @@ void test_H264_Depacketizer_GetNalu_UnsupportedPacket( void )
     h264Packet.pPacketData = &( packetData[ 0 ] );
     h264Packet.packetDataLength = sizeof( packetData );
     ctx.pPacketsArray = &( h264Packet );
+    ctx.packetsArrayLength = 1;
     ctx.packetCount = 1;
     ctx.tailIndex = 0;
 
@@ -1861,6 +1862,7 @@ void test_H264_Depacketizer_GetNalu_PayloadOutOfMemory( void )
     h264Packet.pPacketData = &( packetData[ 0 ] );
     h264Packet.packetDataLength = sizeof( packetData );
     ctx.pPacketsArray = &( h264Packet );
+    ctx.packetsArrayLength = 1;
     ctx.packetCount = 1;
     ctx.tailIndex = 0;
 
@@ -1891,6 +1893,7 @@ void test_H264_Depacketizer_GetNalu_HeaderOutOfMemory( void )
     h264Packet.pPacketData = &( packetData[ 0 ] );
     h264Packet.packetDataLength = sizeof( packetData );
     ctx.pPacketsArray = &( h264Packet );
+    ctx.packetsArrayLength = 1;
     ctx.packetCount = 1;
     ctx.tailIndex = 0;
 

--- a/test/unit-test/h265/h265_utest.c
+++ b/test/unit-test/h265/h265_utest.c
@@ -902,7 +902,7 @@ void test_H265_Packetizer_GetPacket_One_Aggregate_And_One_Single_Nalu_Packet( vo
                                    packet.packetDataLength );
 
     /* Should get single NALU packet. */
-    packet.packetDataLength = 14;
+    packet.packetDataLength = MAX_H265_PACKET_LENGTH;
     result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
     TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
     TEST_ASSERT_EQUAL( sizeof( naluData3 ), packet.packetDataLength );
@@ -953,6 +953,172 @@ void test_H265_Packetizer_GetPacket_BadParams( void )
     result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
 
     TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265 packetization GetPacket with corrupted state validation.
+ */
+void test_H265_Packetizer_GetPacket_Corrupted_State_Validation( void )
+{
+    H265PacketizerContext_t ctx;
+    H265Result_t result;
+    H265Nalu_t naluArray[ MAX_NALUS_IN_A_FRAME ];
+    uint8_t naluData[] = { 0x40, 0x01, 0xAA, 0xBB };
+    H265Nalu_t nalu = { .pNaluData = &( naluData[ 0 ] ), .naluDataLength = sizeof( naluData ) };
+    H265Packet_t packet = { .pPacketData = &( packetBuffer[ 0 ] ), .packetDataLength = MAX_H265_PACKET_LENGTH };
+
+    result = H265Packetizer_Init( &( ctx ), &( naluArray[ 0 ] ), MAX_NALUS_IN_A_FRAME );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    /* Test tailIndex out of bounds */
+    ctx.tailIndex = MAX_NALUS_IN_A_FRAME;
+    result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
+
+    /* Reset and test NULL NALU data */
+    ctx.tailIndex = 0;
+    ctx.pNaluArray[ ctx.tailIndex ].pNaluData = NULL;
+    result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
+
+    /* Reset and test zero NALU length */
+    ctx.pNaluArray[ ctx.tailIndex ].pNaluData = &( naluData[ 0 ] );
+    ctx.pNaluArray[ ctx.tailIndex ].naluDataLength = 0;
+    result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_MALFORMED_PACKET, result );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265 packetization GetPacket with aggregation loop index overflow.
+ */
+void test_H265_Packetizer_GetPacket_Aggregation_Loop_Index_Overflow( void )
+{
+    H265PacketizerContext_t ctx;
+    H265Result_t result;
+    H265Nalu_t naluArray[ 2 ];
+    uint8_t naluData[] = { 0x40, 0x01, 0xAA, 0xBB };
+    H265Nalu_t nalu = { .pNaluData = &( naluData[ 0 ] ), .naluDataLength = sizeof( naluData ) };
+    H265Packet_t packet = { .pPacketData = &( packetBuffer[ 0 ] ), .packetDataLength = MAX_H265_PACKET_LENGTH };
+
+    result = H265Packetizer_Init( &( ctx ), &( naluArray[ 0 ] ), 2 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    /* Corrupt tailIndex to trigger overflow in aggregation loop */
+    ctx.tailIndex = 1;
+
+    result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265 packetization GetPacket when aggregation loop detects overflow.
+ */
+void test_H265_Packetizer_GetPacket_Aggregation_Detects_Overflow( void )
+{
+    H265PacketizerContext_t ctx;
+    H265Result_t result;
+    H265Nalu_t naluArray[ 3 ];
+    uint8_t naluData[] = { 0x40, 0x01, 0xAA, 0xBB };
+    H265Nalu_t nalu = { .pNaluData = &( naluData[ 0 ] ), .naluDataLength = sizeof( naluData ) };
+    H265Packet_t packet = { .pPacketData = &( packetBuffer[ 0 ] ), .packetDataLength = MAX_H265_PACKET_LENGTH };
+
+    result = H265Packetizer_Init( &( ctx ), &( naluArray[ 0 ] ), 3 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    ctx.tailIndex = 2;
+    ctx.naluCount = 2;
+
+    result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265 packetization GetPacket with corrupted FU state causing index overflow.
+ */
+void test_H265_Packetizer_GetPacket_Fragmentation_Corrupted_State_Index_Overflow( void )
+{
+    H265PacketizerContext_t ctx;
+    H265Result_t result;
+    H265Nalu_t naluArray[ MAX_NALUS_IN_A_FRAME ];
+    uint8_t naluData[ 10 ] =
+    {
+        0x40, 0x01,
+        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22
+    };
+    H265Nalu_t nalu =
+    {
+        .pNaluData = &( naluData[ 0 ] ),
+        .naluDataLength = sizeof( naluData )
+    };
+    H265Packet_t packet =
+    {
+        .pPacketData = &( packetBuffer[ 0 ] ),
+        .packetDataLength = 6
+    };
+
+    result = H265Packetizer_Init( &( ctx ), &( naluArray[ 0 ] ), MAX_NALUS_IN_A_FRAME );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    /* Corrupt the FU state to trigger overflow check */
+    ctx.fuPacketizationState.naluDataIndex = sizeof( naluData ) + 1;
+
+    packet.packetDataLength = 6;
+    result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265 packetization AddNalu with corrupted headIndex.
+ */
+void test_H265_Packetizer_AddNalu_Corrupted_HeadIndex( void )
+{
+    H265PacketizerContext_t ctx;
+    H265Result_t result;
+    H265Nalu_t naluArray[ 2 ];
+    uint8_t naluData[] = { 0x40, 0x01, 0xAA, 0xBB };
+    H265Nalu_t nalu = { .pNaluData = &( naluData[ 0 ] ), .naluDataLength = sizeof( naluData ) };
+
+    result = H265Packetizer_Init( &( ctx ), &( naluArray[ 0 ] ), 2 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    /* Corrupt headIndex to exceed array length */
+    ctx.headIndex = 2;
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
 }
 
 /*-----------------------------------------------------------*/
@@ -1122,13 +1288,41 @@ void test_H265_Depacketizer_GetNalu_BadParams( void )
     H265DepacketizerContext_t ctx;
     H265Nalu_t nalu;
     H265Result_t result;
+    H265Packet_t packetsArray[ 1 ];
+    uint8_t naluBuffer[ 10 ];
 
     result = H265Depacketizer_GetNalu( NULL, &( nalu ) );
-
     TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
 
     result = H265Depacketizer_GetNalu( &( ctx ), NULL );
+    TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
 
+    /* Test NULL NALU data */
+    H265Depacketizer_Init( &( ctx ), &( packetsArray[ 0 ] ), 1 );
+    nalu.pNaluData = NULL;
+    nalu.naluDataLength = 10;
+    ctx.packetCount = 1;
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
+
+    /* Test tail index out of bounds */
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    ctx.tailIndex = 1;
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
+
+    /* Test NULL packet data in array */
+    ctx.tailIndex = 0;
+    packetsArray[ 0 ].pPacketData = NULL;
+    packetsArray[ 0 ].packetDataLength = 10;
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
+
+    /* Test zero packet data length in array */
+    uint8_t packetData[] = { 0x01, 0x02 };
+    packetsArray[ 0 ].pPacketData = &( packetData[ 0 ] );
+    packetsArray[ 0 ].packetDataLength = 0;
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
     TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
 }
 
@@ -1958,13 +2152,26 @@ void test_H265Depacketizer_AddPacket_BadParams( void )
     H265DepacketizerContext_t ctx;
     H265Packet_t packet;
     H265Result_t result;
+    H265Packet_t packetsArray[ 1 ];
 
     result = H265Depacketizer_AddPacket( &( ctx ), NULL );
-
     TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
 
     result = H265Depacketizer_AddPacket( NULL, &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
 
+    /* Test NULL packet data */
+    H265Depacketizer_Init( &( ctx ), &( packetsArray[ 0 ] ), 1 );
+    packet.pPacketData = NULL;
+    packet.packetDataLength = 10;
+    result = H265Depacketizer_AddPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
+
+    /* Test zero packet data length */
+    uint8_t packetData[] = { 0x01, 0x02 };
+    packet.pPacketData = &( packetData[ 0 ] );
+    packet.packetDataLength = 0;
+    result = H265Depacketizer_AddPacket( &( ctx ), &( packet ) );
     TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
 }
 
@@ -2004,6 +2211,33 @@ void test_H265Depacketizer_AddPacket_OutOfMemory( void )
 
     result = H265Depacketizer_AddPacket( &( ctx ), &( packet ) );
 
+    TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265 depacketization AddPacket with headIndex overflow.
+ */
+void test_H265Depacketizer_AddPacket_HeadIndex_Overflow( void )
+{
+    H265DepacketizerContext_t ctx;
+    H265Result_t result;
+    H265Packet_t packetsArray[ 2 ];
+    uint8_t packetData[] = { 0x01, 0x02, 0x03, 0x04 };
+    H265Packet_t packet =
+    {
+        .pPacketData = &( packetData[ 0 ] ),
+        .packetDataLength = sizeof( packetData )
+    };
+
+    result = H265Depacketizer_Init( &( ctx ), &( packetsArray[ 0 ] ), 2 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    /* Manually set headIndex to trigger overflow */
+    ctx.headIndex = 2;
+
+    result = H265Depacketizer_AddPacket( &( ctx ), &( packet ) );
     TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
 }
 
@@ -2192,6 +2426,92 @@ void test_H265_Depacketizer_GetPacketProperties_Unsupported_Packet( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Test H265 depacketization of aggregation packet with overflow.
+ */
+void test_H265Depacketizer_GetNalu_Aggregation_Packet_Overflow( void )
+{
+    H265DepacketizerContext_t ctx;
+    H265Result_t result;
+    H265Packet_t packetsArray[ 10 ];
+    H265Nalu_t nalu =
+    {
+        .pNaluData = &( frameBuffer[ 0 ] ),
+        .naluDataLength = MAX_FRAME_LENGTH
+    };
+    uint8_t aggregationPacketData[] =
+    {
+        0x60, 0x01, /* Payload header: Type=48, TID=1. */
+        0x00, 0x04, /* NALU1 Size. */
+        0x40, 0x01, 0xAA, 0xBB, /* NALU1 payload. */
+    };
+    H265Packet_t aggregationPacket =
+    {
+        .pPacketData = &( aggregationPacketData[ 0 ] ),
+        .packetDataLength = sizeof( aggregationPacketData )
+    };
+
+    result = H265Depacketizer_Init( &( ctx ), &( packetsArray[ 0 ] ), 10 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Depacketizer_AddPacket( &( ctx ), &( aggregationPacket ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    /* Set curPacketIndex to SIZE_MAX - 1 to trigger overflow check */
+    ctx.curPacketIndex = SIZE_MAX - 1;
+
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265 depacketization of aggregation packet with insufficient data.
+ */
+void test_H265Depacketizer_GetNalu_Aggregation_Packet_Insufficient_Data( void )
+{
+    H265DepacketizerContext_t ctx;
+    H265Result_t result;
+    H265Packet_t packetsArray[ 10 ];
+    H265Nalu_t nalu =
+    {
+        .pNaluData = &( frameBuffer[ 0 ] ),
+        .naluDataLength = MAX_FRAME_LENGTH
+    };
+    uint8_t aggregationPacketData[] =
+    {
+        0x60, 0x01, /* Payload header: Type=48, TID=1. */
+        0x00, 0x04, /* NALU1 Size. */
+        0x40, 0x01, 0xAA, 0xBB, /* NALU1 payload. */
+    };
+    H265Packet_t aggregationPacket =
+    {
+        .pPacketData = &( aggregationPacketData[ 0 ] ),
+        .packetDataLength = sizeof( aggregationPacketData )
+    };
+
+    result = H265Depacketizer_Init( &( ctx ), &( packetsArray[ 0 ] ), 10 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Depacketizer_AddPacket( &( ctx ), &( aggregationPacket ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    /* Get first NALU successfully */
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    /* Set curPacketIndex near end to trigger insufficient data check */
+    ctx.curPacketIndex = sizeof( aggregationPacketData ) - 1;
+    ctx.tailIndex = 0;
+    ctx.packetCount = 1;
+
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Test H265 depacketization GetPacketProperties for bad params.
  */
 void test_H265_Depacketizer_GetPacketProperties_BadParams( void )
@@ -2228,5 +2548,6 @@ void test_H265_Depacketizer_GetPacketProperties_BadParams( void )
 
     TEST_ASSERT_EQUAL( H265_RESULT_BAD_PARAM, result );
 }
+
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/opus/opus_utest.c
+++ b/test/unit-test/opus/opus_utest.c
@@ -164,6 +164,15 @@ void test_Opus_Packetizer_GetPacket_BadParams( void )
     TEST_ASSERT_EQUAL( OPUS_RESULT_BAD_PARAM,
                        result );
 
+    pkt.pPacketData = NULL;
+    pkt.packetDataLength = PACKET_BUFFER_LENGTH;
+
+    result = OpusPacketizer_GetPacket( &( ctx ),
+                                       &( pkt ) );
+
+    TEST_ASSERT_EQUAL( OPUS_RESULT_BAD_PARAM,
+                       result );
+
     pkt.pPacketData = &( packetBuffer[ 0 ] );
     pkt.packetDataLength = 0;
 

--- a/test/unit-test/rtp_api/rtp_api_utest.c
+++ b/test/unit-test/rtp_api/rtp_api_utest.c
@@ -1532,6 +1532,39 @@ void test_Rtp_DeSerialize_InsufficientExtensionPayloadData( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate Rtp_DeSerialize with zero padding octets.
+ */
+void test_Rtp_DeSerialize_ZeroPaddingOctets( void )
+{
+    RtpResult_t result;
+    RtpContext_t ctx = { 0 };
+    RtpPacket_t packet = { 0 };
+    uint8_t serializedPacket[] =
+    {
+        /* RTP header: V = 2, P = 1, PT = 0x60, Sequence Number = 0x04D2. */
+        0xA0, 0x60, 0x04, 0xD2,
+        /* Timestamp. */
+        0x12, 0x34, 0x56, 0x78,
+        /* SSRC. */
+        0x9A, 0xBC, 0xDE, 0xFF,
+        /* RTP payload with 0 padding octets. */
+        0x12, 0x34, 0x56, 0x00
+    };
+
+    result = Rtp_Init( &( ctx ) );
+    TEST_ASSERT_EQUAL( RTP_RESULT_OK, result );
+
+    result = Rtp_DeSerialize( &( ctx ),
+                              &( serializedPacket[ 0 ] ),
+                              sizeof( serializedPacket ),
+                              &( packet ) );
+
+    TEST_ASSERT_EQUAL( RTP_RESULT_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Validate Rtp_DeSerialize with no payload data.
  */
 void test_Rtp_DeSerialize_NoPayload( void )

--- a/test/unit-test/rtp_api/rtp_api_utest.c
+++ b/test/unit-test/rtp_api/rtp_api_utest.c
@@ -5,6 +5,7 @@
 /* Standard includes. */
 #include <string.h>
 #include <stdint.h>
+#include <stddef.h>
 
 /* API includes. */
 #include "rtp_api.h"
@@ -544,6 +545,84 @@ void test_Rtp_Serialize_Pass_ZeroPayloadLength( void )
     TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedSerializedPacket[ 0 ] ),
                                    pRtpBuffer,
                                    rtpBufferLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Rtp_Serialize with invalid CSRC count > 15.
+ */
+void test_Rtp_Serialize_InvalidCsrcCount( void )
+{
+    RtpResult_t result;
+    RtpContext_t ctx = { 0 };
+    RtpPacket_t packet = { 0 };
+    size_t rtpBufferLength = RTP_BUFFER_LENGTH;
+
+    Rtp_Init( &( ctx ) );
+
+    packet.header.csrcCount = 16; /* Invalid: exceeds maximum of 15 */
+
+    result = Rtp_Serialize( &( ctx ),
+                            &( packet ),
+                            pRtpBuffer,
+                            &( rtpBufferLength ) );
+
+    TEST_ASSERT_EQUAL( RTP_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Rtp_Serialize with payload length causing overflow.
+ */
+void test_Rtp_Serialize_PayloadLengthOverflow( void )
+{
+    RtpResult_t result;
+    RtpContext_t ctx = { 0 };
+    RtpPacket_t packet = { 0 };
+    size_t rtpBufferLength = RTP_BUFFER_LENGTH;
+
+    Rtp_Init( &( ctx ) );
+
+    packet.payloadLength = SIZE_MAX - 10; /* Large payload causing overflow */
+
+    result = Rtp_Serialize( &( ctx ),
+                            &( packet ),
+                            pRtpBuffer,
+                            &( rtpBufferLength ) );
+
+    TEST_ASSERT_EQUAL( RTP_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Rtp_Serialize with zero padding length.
+ */
+void test_Rtp_Serialize_ZeroPaddingLength( void )
+{
+    RtpResult_t result;
+    RtpContext_t ctx = { 0 };
+    RtpPacket_t packet = { 0 };
+    size_t rtpBufferLength = RTP_BUFFER_LENGTH;
+    uint8_t rtpPayload[] = { 0x12, 0x34, 0x56, 0x00 };
+
+    Rtp_Init( &( ctx ) );
+
+    packet.header.flags = RTP_HEADER_FLAG_PADDING;
+    packet.pPayload = rtpPayload;
+    packet.payloadLength = sizeof( rtpPayload );
+
+    result = Rtp_Serialize( &( ctx ),
+                            &( packet ),
+                            pRtpBuffer,
+                            &( rtpBufferLength ) );
+
+    TEST_ASSERT_EQUAL( RTP_RESULT_MALFORMED_PACKET,
+                       result );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/rtp_packet_queue/rtp_packet_queue_utest.c
+++ b/test/unit-test/rtp_packet_queue/rtp_packet_queue_utest.c
@@ -82,6 +82,23 @@ void test_RtpPacketQueue_Init_BadParams( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Validate RtpPacketQueue_Init with array length causing overflow.
+ */
+void test_RtpPacketQueue_Init_ArrayLengthOverflow( void )
+{
+    RtpPacketQueueResult_t result;
+    RtpPacketQueue_t queue = { 0 };
+    RtpPacketInfo_t packetInfoArray[2];
+    size_t overflowLength = SIZE_MAX / sizeof( RtpPacketInfo_t ) + 1;
+
+    result = RtpPacketQueue_Init( &queue, packetInfoArray, overflowLength );
+
+    TEST_ASSERT_EQUAL( RTP_PACKET_QUEUE_RESULT_BAD_PARAM, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Validate Enqueue functionality in case of bad parameters.
  */
 void test_RtpPacketQueue_Enqueue_BadParams( void )

--- a/test/unit-test/vp8/vp8_utest.c
+++ b/test/unit-test/vp8/vp8_utest.c
@@ -1705,6 +1705,8 @@ void test_VP8_Depacketizer_GetFrame_MalformedPacket( void )
                        result );
 }
 
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Validate VP8_Depacketizer_GetPacketProperties incase of bad parameters.
  */
@@ -1785,3 +1787,209 @@ void test_VP8_Depacketizer_GetFrame_XBitSet_MissingExtension( void )
     TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET,
                        result );
 }
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate VP8_Depacketizer_GetFrame with 15-bit picture ID but insufficient data.
+ */
+void test_VP8_Depacketizer_GetFrame_PictureID_15Bit_Incomplete( void )
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Packet_t pkt;
+    VP8Frame_t frame;
+    uint8_t packetData[] = { 0x80, 0x80, 0x80 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = VP8Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+
+    result = VP8Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate VP8_Depacketizer_GetFrame with TL0PICIDX extension but insufficient data.
+ */
+void test_VP8_Depacketizer_GetFrame_TL0PICIDX_Incomplete( void )
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Packet_t pkt;
+    VP8Frame_t frame;
+    uint8_t packetData[] = { 0x80, 0x40 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = VP8Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+
+    result = VP8Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate VP8_Depacketizer_GetFrame with TID/KEYIDX extension but insufficient data.
+ */
+void test_VP8_Depacketizer_GetFrame_TID_KEYIDX_Incomplete( void )
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Packet_t pkt;
+    VP8Frame_t frame;
+    uint8_t packetData[] = { 0x80, 0x30 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = VP8Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+
+    result = VP8Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate VP8_Depacketizer_GetFrame with picture ID extension but insufficient data.
+ */
+void test_VP8_Depacketizer_GetFrame_PictureID_Incomplete( void )
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Packet_t pkt;
+    VP8Frame_t frame;
+    uint8_t packetData[] = { 0x80, 0x80 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = VP8Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+
+    result = VP8Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate VP8_Depacketizer_GetFrame with zero-length packet.
+ */
+void test_VP8_Depacketizer_GetFrame_ZeroLengthPacket( void )
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Frame_t frame;
+    uint8_t packetData[] = { 0x10 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    ctx.pPacketsArray[ 0 ].pPacketData = &( packetData[ 0 ] );
+    ctx.pPacketsArray[ 0 ].packetDataLength = 0;
+    ctx.packetCount = 1;
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+
+    result = VP8Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate VP8_Depacketizer_GetFrame with 1-byte packet without X bit.
+ */
+void test_VP8_Depacketizer_GetFrame_OneByte_NoXBit( void )
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Packet_t pkt;
+    VP8Frame_t frame;
+    uint8_t packetData[] = { 0x00 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = VP8Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK, result );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+
+    result = VP8Depacketizer_GetFrame( &( ctx ), &( frame ) );
+
+    TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate VP8_Depacketizer_GetFrame with payload descriptor length equal to packet length.
+ */

--- a/test/unit-test/vp8/vp8_utest.c
+++ b/test/unit-test/vp8/vp8_utest.c
@@ -688,6 +688,24 @@ void test_VP8_Packetizer_GetPacket_BadParams( void )
 
     TEST_ASSERT_EQUAL( VP8_RESULT_BAD_PARAM,
                        result );
+
+    pkt.pPacketData = NULL;
+    pkt.packetDataLength = PACKET_BUFFER_LENGTH;
+
+    result = VP8Packetizer_GetPacket( &( ctx ),
+                                      &( pkt ) );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_BAD_PARAM,
+                       result );
+
+    pkt.pPacketData = &( packetBuffer[ 0 ] );
+    pkt.packetDataLength = 0;
+
+    result = VP8Packetizer_GetPacket( &( ctx ),
+                                      &( pkt ) );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_BAD_PARAM,
+                       result );
 }
 
 /*-----------------------------------------------------------*/
@@ -1686,12 +1704,10 @@ void test_VP8_Depacketizer_GetFrame_MalformedPacket( void )
     TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET,
                        result );
 }
-/*-----------------------------------------------------------*/
 
 /**
  * @brief Validate VP8_Depacketizer_GetPacketProperties incase of bad parameters.
  */
-
 void test_VP8_Depacketizer_GetPacketProperties_BadParams( void )
 {
     VP8Result_t result;
@@ -1732,3 +1748,40 @@ void test_VP8_Depacketizer_GetPacketProperties_BadParams( void )
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate VP8_Depacketizer_GetFrame with packet having X bit but missing extension byte.
+ */
+void test_VP8_Depacketizer_GetFrame_XBitSet_MissingExtension( void )
+{
+    VP8DepacketizerContext_t ctx;
+    VP8Result_t result;
+    VP8Packet_t pkt;
+    VP8Frame_t frame;
+    uint8_t packetData[] = { 0x80 };
+
+    result = VP8Depacketizer_Init( &( ctx ),
+                                   &( packetsArray[ 0 ] ),
+                                   VP8_PACKETS_ARR_LEN );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK,
+                       result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = VP8Depacketizer_AddPacket( &( ctx ),
+                                        &( pkt ) );
+
+    TEST_ASSERT_EQUAL( VP8_RESULT_OK,
+                       result );
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = VP8_FRAME_BUF_LEN;
+
+    result = VP8Depacketizer_GetFrame( &( ctx ),
+                                       &( frame ) );
+
+    TEST_ASSERT_EQUAL( VP8_MALFORMED_PACKET,
+                       result );
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes critical security vulnerabilities in RTP packet processing:
- Added integer overflow protection in packet size calculations
- Enhanced bounds checking to prevent buffer overflows
- Clear output structures on error to prevent information disclosure

*Testing*

Ran coverity to check for any issues with the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
