### PR TITLE
Fix integer overflow of length in depacketizer

### DIFF
--- a/codec_packetizers/h264/h264_depacketizer.c
+++ b/codec_packetizers/h264/h264_depacketizer.c
@@ -132,7 +132,8 @@ static H264Result_t DepacketizeAggregationPacket( H264DepacketizerContext_t * pC
     }
 
     /* Is there enough data left in the packet to read the next NALU size? */
-    if( ( pCtx->curPacketIndex + STAP_A_NALU_SIZE ) <= curPacketLength )
+    if( ( STAP_A_NALU_SIZE <= curPacketLength ) &&
+        ( pCtx->curPacketIndex <= ( curPacketLength - STAP_A_NALU_SIZE ) ) )
     {
         /* Read NALU length. */
         naluLength = pCurPacketData[ pCtx->curPacketIndex ];
@@ -142,7 +143,8 @@ static H264Result_t DepacketizeAggregationPacket( H264DepacketizerContext_t * pC
         pCtx->curPacketIndex += STAP_A_NALU_SIZE;
 
         /* Is there enough data left in the packet to read the next NALU? */
-        if( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
+        if( ( naluLength <= curPacketLength ) &&
+            ( pCtx->curPacketIndex <= ( curPacketLength - naluLength ) ) )
         {
             /* Is there enough space in the output buffer? */
             if( naluLength <= pNalu->naluDataLength)

--- a/codec_packetizers/h264/h264_depacketizer.c
+++ b/codec_packetizers/h264/h264_depacketizer.c
@@ -88,7 +88,8 @@ static H264Result_t DepacketizeFragmentationUnitPacket( H264DepacketizerContext_
 
         /* Write NALU payload. */
         payloadLength = curPacketLength - FU_A_HEADER_SIZE;
-        if( ( curNaluDataIndex + payloadLength ) <= pNalu->naluDataLength )
+        if( ( payloadLength <= pNalu->naluDataLength ) &&
+            ( curNaluDataIndex <= ( pNalu->naluDataLength - payloadLength ) ) )
         {
             memcpy( ( void * ) &( pNalu->pNaluData[ curNaluDataIndex ] ),
                     ( const void * ) &( pCurPacketData[ FU_A_PAYLOAD_OFFSET ] ),

--- a/codec_packetizers/h264/h264_depacketizer.c
+++ b/codec_packetizers/h264/h264_depacketizer.c
@@ -132,7 +132,7 @@ static H264Result_t DepacketizeAggregationPacket( H264DepacketizerContext_t * pC
     }
 
     /* Is there enough data left in the packet to read the next NALU size? */
-    if( ( STAP_A_NALU_SIZE <= curPacketLength ) &&
+    if( ( curPacketLength >= STAP_A_NALU_SIZE ) &&
         ( pCtx->curPacketIndex <= ( curPacketLength - STAP_A_NALU_SIZE ) ) )
     {
         /* Read NALU length. */

--- a/codec_packetizers/h265/h265_depacketizer.c
+++ b/codec_packetizers/h265/h265_depacketizer.c
@@ -90,7 +90,8 @@ static H265Result_t DepacketizeFragmentationUnitPacket( H265DepacketizerContext_
 
         /* Write NALU payload. */
         payloadLength = curPacketLength - FU_PAYLOAD_HEADER_SIZE - FU_HEADER_SIZE;
-        if( ( curNaluDataIndex + payloadLength ) <= pNalu->naluDataLength )
+        if( ( payloadLength <= pNalu->naluDataLength ) &&
+            ( curNaluDataIndex <= ( pNalu->naluDataLength - payloadLength ) ) )
         {
             memcpy( ( void * ) &( pNalu->pNaluData[ curNaluDataIndex ] ),
                     ( const void * ) &( pCurPacketData[ FU_PAYLOAD_HEADER_SIZE + FU_HEADER_SIZE ] ),
@@ -144,7 +145,8 @@ static H265Result_t DepacketizeAggregationPacket( H265DepacketizerContext_t * pC
         pCtx->curPacketIndex += AP_NALU_LENGTH_FIELD_SIZE;
 
         /* Is there enough data left in the packet to read the next NALU? */
-        if( ( pCtx->curPacketIndex + naluLength ) <= curPacketLength )
+        if( ( naluLength <= curPacketLength ) &&
+            ( pCtx->curPacketIndex <= ( curPacketLength - naluLength ) ) )
         {
             /* Is there enough space in the output buffer? */
             if( naluLength <= pNalu->naluDataLength )

--- a/codec_packetizers/h265/h265_packetizer.c
+++ b/codec_packetizers/h265/h265_packetizer.c
@@ -455,7 +455,8 @@ H265Result_t H265Packetizer_GetPacket( H265PacketizerContext_t * pCtx,
                     naluSize = pCtx->pNaluArray[ pCtx->tailIndex + i ].naluDataLength;
 
                     /* Can we fit in this NAL unit? */
-                    if( ( aggregatePacketSize + AP_NALU_LENGTH_FIELD_SIZE + naluSize ) <= pPacket->packetDataLength )
+                    if( ( AP_NALU_LENGTH_FIELD_SIZE + naluSize <= pPacket->packetDataLength ) &&
+                        ( aggregatePacketSize <= ( pPacket->packetDataLength - AP_NALU_LENGTH_FIELD_SIZE - naluSize ) ) )
                     {
                         aggregatePacketSize += ( AP_NALU_LENGTH_FIELD_SIZE + naluSize );
                         nalusToAggregate += 1;

--- a/codec_packetizers/h265/h265_packetizer.c
+++ b/codec_packetizers/h265/h265_packetizer.c
@@ -455,7 +455,7 @@ H265Result_t H265Packetizer_GetPacket( H265PacketizerContext_t * pCtx,
                     naluSize = pCtx->pNaluArray[ pCtx->tailIndex + i ].naluDataLength;
 
                     /* Can we fit in this NAL unit? */
-                    if( ( AP_NALU_LENGTH_FIELD_SIZE + naluSize <= pPacket->packetDataLength ) &&
+                    if( ( pPacket->packetDataLength >= ( AP_NALU_LENGTH_FIELD_SIZE + naluSize ) ) &&
                         ( aggregatePacketSize <= ( pPacket->packetDataLength - AP_NALU_LENGTH_FIELD_SIZE - naluSize ) ) )
                     {
                         aggregatePacketSize += ( AP_NALU_LENGTH_FIELD_SIZE + naluSize );

--- a/codec_packetizers/opus/opus_depacketizer.c
+++ b/codec_packetizers/opus/opus_depacketizer.c
@@ -36,6 +36,7 @@ OpusResult_t OpusDepacketizer_AddPacket( OpusDepacketizerContext_t * pCtx,
 
     if( ( pCtx == NULL ) ||
         ( pPacket == NULL ) ||
+        ( pPacket->pPacketData == NULL ) ||
         ( pPacket->packetDataLength == 0 ) )
     {
         result = OPUS_RESULT_BAD_PARAM;
@@ -88,7 +89,8 @@ OpusResult_t OpusDepacketizer_GetFrame( OpusDepacketizerContext_t * pCtx,
     {
         pPacket = &( pCtx->pPacketsArray[ i ] );
 
-        if( ( pFrame->frameDataLength - currentFrameDataIndex ) >= pPacket->packetDataLength )
+        if( ( pPacket->pPacketData != NULL ) &&
+            ( ( pFrame->frameDataLength - currentFrameDataIndex ) >= pPacket->packetDataLength ) )
         {
             memcpy( ( void * ) &( pFrame->pFrameData[ currentFrameDataIndex ] ),
                     ( const void * ) &( pPacket->pPacketData[ 0 ] ),

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -2213,9 +2213,9 @@ void test_H264_Depacketizer_GetNalu_IntegerOverflow_Protection( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate H264_Depacketizer_StapAGetNalu incase of integer overflow protection
- * when reading NALU data.
-
+ * @brief Validate H264_Depacketizer_GetNalu incase of integer overflow protection
+ * with payloadLength exceeding buffer.
+ */
 void test_H264_Depacketizer_GetNalu_IntegerOverflow_PayloadExceedsBuffer( void )
 {
     H264Result_t result;
@@ -2261,9 +2261,9 @@ void test_H264_Depacketizer_GetNalu_IntegerOverflow_PayloadExceedsBuffer( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Test STAP-A packet with length less than STAP_A_NALU_SIZE (2 bytes).
- * This tests line 135: STAP_A_NALU_SIZE <= curPacketLength
-
+ * @brief Validate H264_Depacketizer_StapAGetNalu incase of integer overflow protection
+ * when reading NALU data.
+ */
 void test_H264_Depacketizer_StapAGetNalu_IntegerOverflow_Protection_NaluData( void )
 {
     H264Result_t result;
@@ -2311,8 +2311,8 @@ void test_H264_Depacketizer_StapAGetNalu_IntegerOverflow_Protection_NaluData( vo
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate H264_Depacketizer_GetNalu incase of integer overflow protection
- * with payloadLength exceeding buffer.
+ * @brief Test STAP-A packet with length less than STAP_A_NALU_SIZE (2 bytes).
+ * This tests line 135: STAP_A_NALU_SIZE <= curPacketLength
  */
 void test_H264_Depacketizer_StapAGetNalu_PacketTooSmall( void )
 {

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -2214,68 +2214,6 @@ void test_H264_Depacketizer_GetNalu_IntegerOverflow_Protection( void )
 
 /**
  * @brief Validate H264_Depacketizer_StapAGetNalu incase of integer overflow protection
- * when reading NALU size.
- */
-void test_H264_Depacketizer_StapAGetNalu_IntegerOverflow_Protection_NaluSize( void )
-{
-    H264Result_t result;
-    H264Packet_t pkt;
-    H264DepacketizerContext_t ctx = { 0 };
-    Nalu_t nalu;
-    uint8_t naluBuffer[ MAX_NALU_LENGTH ];
-    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
-    uint8_t packetData[] =
-    {
-        /* STAP-A header. F=0, NRI=0, Type=24. */
-        0x18,
-        /* NALU 1 length. */
-        0x00, 0x05,
-        /* NALU 1 payload. */
-        0xAB, 0xCD, 0xEF, 0x11, 0x22,
-    };
-
-    result = H264Depacketizer_Init( &( ctx ),
-                                    &( packetsArray[ 0 ] ),
-                                    MAX_PACKETS_IN_A_FRAME );
-
-    TEST_ASSERT_EQUAL( H264_RESULT_OK,
-                       result );
-
-    pkt.pPacketData = &( packetData[ 0 ] );
-    pkt.packetDataLength = sizeof( packetData );
-
-    result = H264Depacketizer_AddPacket( &( ctx ),
-                                         &( pkt ) );
-
-    TEST_ASSERT_EQUAL( H264_RESULT_OK,
-                       result );
-
-    nalu.pNaluData = &( naluBuffer[ 0 ] );
-    nalu.naluDataLength = MAX_NALU_LENGTH;
-
-    result = H264Depacketizer_GetNalu( &( ctx ),
-                                       &( nalu ) );
-
-    TEST_ASSERT_EQUAL( H264_RESULT_OK,
-                       result );
-
-    /* Simulate large curPacketIndex to test overflow protection. */
-    ctx.curPacketIndex = sizeof( packetData ) - 1;
-
-    nalu.pNaluData = &( naluBuffer[ 0 ] );
-    nalu.naluDataLength = MAX_NALU_LENGTH;
-
-    result = H264Depacketizer_GetNalu( &( ctx ),
-                                       &( nalu ) );
-
-    TEST_ASSERT_EQUAL( H264_RESULT_MALFORMED_PACKET,
-                       result );
-}
-
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Validate H264_Depacketizer_StapAGetNalu incase of integer overflow protection
  * when reading NALU data.
  */
 void test_H264_Depacketizer_StapAGetNalu_IntegerOverflow_Protection_NaluData( void )

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -2164,3 +2164,50 @@ void test_H264_Depacketizer_GetNalu_InvalidTailIndex( void )
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate H264_Depacketizer_GetNalu incase of integer overflow protection.
+ */
+void test_H264_Depacketizer_GetNalu_IntegerOverflow_Protection( void )
+{
+    H264Result_t result;
+    H264DepacketizerContext_t ctx = { 0 };
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    Nalu_t nalu;
+    uint8_t naluBuffer[ 100 ];
+    uint8_t fragmentUnitData[] =
+    {
+        0x1C,       /* FU indicator: Type=28. */
+        0x93,       /* FU header: S=1, Type=19. */
+        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22  /* FU payload (8 bytes). */
+    };
+    H264Packet_t fragment =
+    {
+        .pPacketData = &( fragmentUnitData[ 0 ] ),
+        .packetDataLength = sizeof( fragmentUnitData )
+    };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( fragment ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = 5;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -2211,3 +2211,249 @@ void test_H264_Depacketizer_GetNalu_IntegerOverflow_Protection( void )
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate H264_Depacketizer_StapAGetNalu incase of integer overflow protection
+ * when reading NALU size.
+ */
+void test_H264_Depacketizer_StapAGetNalu_IntegerOverflow_Protection_NaluSize( void )
+{
+    H264Result_t result;
+    H264Packet_t pkt;
+    H264DepacketizerContext_t ctx = { 0 };
+    Nalu_t nalu;
+    uint8_t naluBuffer[ MAX_NALU_LENGTH ];
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData[] =
+    {
+        /* STAP-A header. F=0, NRI=0, Type=24. */
+        0x18,
+        /* NALU 1 length. */
+        0x00, 0x05,
+        /* NALU 1 payload. */
+        0xAB, 0xCD, 0xEF, 0x11, 0x22,
+    };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    /* Simulate large curPacketIndex to test overflow protection. */
+    ctx.curPacketIndex = sizeof( packetData ) - 1;
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate H264_Depacketizer_StapAGetNalu incase of integer overflow protection
+ * when reading NALU data.
+ */
+void test_H264_Depacketizer_StapAGetNalu_IntegerOverflow_Protection_NaluData( void )
+{
+    H264Result_t result;
+    H264Packet_t pkt;
+    H264DepacketizerContext_t ctx = { 0 };
+    Nalu_t nalu;
+    uint8_t naluBuffer[ MAX_NALU_LENGTH ];
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData[] =
+    {
+        /* STAP-A header. F=0, NRI=0, Type=24. */
+        0x18,
+        /* NALU 1 length (large value). */
+        0xFF, 0xFF,
+        /* NALU 1 payload (incomplete). */
+        0xAB, 0xCD,
+    };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate H264_Depacketizer_GetNalu incase of integer overflow protection
+ * with payloadLength exceeding buffer.
+ */
+void test_H264_Depacketizer_GetNalu_IntegerOverflow_PayloadExceedsBuffer( void )
+{
+    H264Result_t result;
+    H264DepacketizerContext_t ctx = { 0 };
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    Nalu_t nalu;
+    uint8_t naluBuffer[ 10 ];
+    uint8_t fragmentUnitData[] =
+    {
+        0x1C,       /* FU indicator: Type=28. */
+        0x93,       /* FU header: S=1, Type=19. */
+        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22, 0x33, 0x44, 0x55  /* FU payload (11 bytes). */
+    };
+    H264Packet_t fragment =
+    {
+        .pPacketData = &( fragmentUnitData[ 0 ] ),
+        .packetDataLength = sizeof( fragmentUnitData )
+    };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( fragment ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = sizeof( naluBuffer );
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test STAP-A packet with length less than STAP_A_NALU_SIZE (2 bytes).
+ * This tests line 135: STAP_A_NALU_SIZE <= curPacketLength
+ */
+void test_H264_Depacketizer_StapAGetNalu_PacketTooSmall( void )
+{
+    H264Result_t result;
+    H264Packet_t pkt;
+    H264DepacketizerContext_t ctx = { 0 };
+    Nalu_t nalu;
+    uint8_t naluBuffer[ MAX_NALU_LENGTH ];
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData[] =
+    {
+        0x18
+    };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = sizeof( packetData );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test STAP-A packet with 2-byte length.
+ */
+void test_H264_Depacketizer_StapAGetNalu_TwoBytePacket( void )
+{
+    H264Result_t result;
+    H264Packet_t pkt;
+    H264DepacketizerContext_t ctx = { 0 };
+    Nalu_t nalu;
+    uint8_t naluBuffer[ MAX_NALU_LENGTH ];
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    uint8_t packetData[] = { 0x18, 0x00 };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    pkt.pPacketData = &( packetData[ 0 ] );
+    pkt.packetDataLength = 2;
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = MAX_NALU_LENGTH;
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_MALFORMED_PACKET,
+                       result );
+}
+
+/*-----------------------------------------------------------*/

--- a/test/unit-test/h264/h264_utest.c
+++ b/test/unit-test/h264/h264_utest.c
@@ -2215,7 +2215,55 @@ void test_H264_Depacketizer_GetNalu_IntegerOverflow_Protection( void )
 /**
  * @brief Validate H264_Depacketizer_StapAGetNalu incase of integer overflow protection
  * when reading NALU data.
- */
+
+void test_H264_Depacketizer_GetNalu_IntegerOverflow_PayloadExceedsBuffer( void )
+{
+    H264Result_t result;
+    H264DepacketizerContext_t ctx = { 0 };
+    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
+    Nalu_t nalu;
+    uint8_t naluBuffer[ 10 ];
+    uint8_t fragmentUnitData[] =
+    {
+        0x1C,       /* FU indicator: Type=28. */
+        0x93,       /* FU header: S=1, Type=19. */
+        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22, 0x33, 0x44, 0x55  /* FU payload (11 bytes). */
+    };
+    H264Packet_t fragment =
+    {
+        .pPacketData = &( fragmentUnitData[ 0 ] ),
+        .packetDataLength = sizeof( fragmentUnitData )
+    };
+
+    result = H264Depacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKETS_IN_A_FRAME );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    result = H264Depacketizer_AddPacket( &( ctx ),
+                                         &( fragment ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OK,
+                       result );
+
+    nalu.pNaluData = &( naluBuffer[ 0 ] );
+    nalu.naluDataLength = sizeof( naluBuffer );
+
+    result = H264Depacketizer_GetNalu( &( ctx ),
+                                       &( nalu ) );
+
+    TEST_ASSERT_EQUAL( H264_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test STAP-A packet with length less than STAP_A_NALU_SIZE (2 bytes).
+ * This tests line 135: STAP_A_NALU_SIZE <= curPacketLength
+
 void test_H264_Depacketizer_StapAGetNalu_IntegerOverflow_Protection_NaluData( void )
 {
     H264Result_t result;
@@ -2265,54 +2313,6 @@ void test_H264_Depacketizer_StapAGetNalu_IntegerOverflow_Protection_NaluData( vo
 /**
  * @brief Validate H264_Depacketizer_GetNalu incase of integer overflow protection
  * with payloadLength exceeding buffer.
- */
-void test_H264_Depacketizer_GetNalu_IntegerOverflow_PayloadExceedsBuffer( void )
-{
-    H264Result_t result;
-    H264DepacketizerContext_t ctx = { 0 };
-    H264Packet_t packetsArray[ MAX_PACKETS_IN_A_FRAME ];
-    Nalu_t nalu;
-    uint8_t naluBuffer[ 10 ];
-    uint8_t fragmentUnitData[] =
-    {
-        0x1C,       /* FU indicator: Type=28. */
-        0x93,       /* FU header: S=1, Type=19. */
-        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22, 0x33, 0x44, 0x55  /* FU payload (11 bytes). */
-    };
-    H264Packet_t fragment =
-    {
-        .pPacketData = &( fragmentUnitData[ 0 ] ),
-        .packetDataLength = sizeof( fragmentUnitData )
-    };
-
-    result = H264Depacketizer_Init( &( ctx ),
-                                    &( packetsArray[ 0 ] ),
-                                    MAX_PACKETS_IN_A_FRAME );
-
-    TEST_ASSERT_EQUAL( H264_RESULT_OK,
-                       result );
-
-    result = H264Depacketizer_AddPacket( &( ctx ),
-                                         &( fragment ) );
-
-    TEST_ASSERT_EQUAL( H264_RESULT_OK,
-                       result );
-
-    nalu.pNaluData = &( naluBuffer[ 0 ] );
-    nalu.naluDataLength = sizeof( naluBuffer );
-
-    result = H264Depacketizer_GetNalu( &( ctx ),
-                                       &( nalu ) );
-
-    TEST_ASSERT_EQUAL( H264_RESULT_OUT_OF_MEMORY,
-                       result );
-}
-
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test STAP-A packet with length less than STAP_A_NALU_SIZE (2 bytes).
- * This tests line 135: STAP_A_NALU_SIZE <= curPacketLength
  */
 void test_H264_Depacketizer_StapAGetNalu_PacketTooSmall( void )
 {

--- a/test/unit-test/h265/h265_utest.c
+++ b/test/unit-test/h265/h265_utest.c
@@ -2551,3 +2551,182 @@ void test_H265_Depacketizer_GetPacketProperties_BadParams( void )
 
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265Packetizer_GetPacket aggregation overflow.
+ */
+void test_H265_Packetizer_GetPacket_Aggregation_Overflow( void )
+{
+    H265Result_t result;
+    H265PacketizerContext_t ctx = { 0 };
+    H265Nalu_t nalusArray[ 2 ];
+    H265Packet_t pkt;
+    uint8_t pktBuffer[ 20 ];
+    uint8_t naluData1[] = { 0x00, 0x01, 0x02 };
+    uint8_t naluData2[] = { 0x03, 0x04, 0x05 };
+
+    nalusArray[ 0 ].pNaluData = naluData1;
+    nalusArray[ 0 ].naluDataLength = sizeof( naluData1 );
+    nalusArray[ 1 ].pNaluData = naluData2;
+    nalusArray[ 1 ].naluDataLength = sizeof( naluData2 );
+
+    result = H265Packetizer_Init( &( ctx ), nalusArray, 2 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalusArray[ 0 ] ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalusArray[ 1 ] ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    ctx.tailIndex = 1;
+
+    pkt.pPacketData = pktBuffer;
+    pkt.packetDataLength = sizeof( pktBuffer );
+
+    result = H265Packetizer_GetPacket( &( ctx ), &( pkt ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265Depacketizer FU payload overflow.
+ */
+void test_H265_Depacketizer_FU_Payload_Overflow( void )
+{
+    H265Result_t result;
+    H265DepacketizerContext_t ctx = { 0 };
+    H265Packet_t packetsArray[ 2 ];
+    H265Nalu_t nalu;
+    uint8_t naluBuffer[ 3 ];
+    uint8_t packetData[] = { 0x62, 0x01, 0x80, 0xAA, 0xBB, 0xCC };
+
+    result = H265Depacketizer_Init( &( ctx ), packetsArray, 2 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    H265Packet_t pkt = { packetData, sizeof( packetData ) };
+    result = H265Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    nalu.pNaluData = naluBuffer;
+    nalu.naluDataLength = sizeof( naluBuffer );
+
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265Depacketizer AP packet with 3-byte length.
+ */
+void test_H265_Depacketizer_AP_ThreeBytePacket( void )
+{
+    H265Result_t result;
+    H265DepacketizerContext_t ctx = { 0 };
+    H265Packet_t packetsArray[ 1 ];
+    H265Nalu_t nalu;
+    uint8_t naluBuffer[ 100 ];
+    uint8_t packetData[] = { 0x60, 0x01, 0x00 };
+
+    result = H265Depacketizer_Init( &( ctx ), packetsArray, 1 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    H265Packet_t pkt = { packetData, 3 };
+    result = H265Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    nalu.pNaluData = naluBuffer;
+    nalu.naluDataLength = sizeof( naluBuffer );
+
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265Depacketizer AP packet with large NALU length.
+ */
+void test_H265_Depacketizer_AP_LargeNaluLength( void )
+{
+    H265Result_t result;
+    H265DepacketizerContext_t ctx = { 0 };
+    H265Packet_t packetsArray[ 1 ];
+    H265Nalu_t nalu;
+    uint8_t naluBuffer[ 100 ];
+    uint8_t packetData[] = { 0x60, 0x01, 0xFF, 0xFF, 0xAA };
+
+    result = H265Depacketizer_Init( &( ctx ), packetsArray, 1 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    H265Packet_t pkt = { packetData, sizeof( packetData ) };
+    result = H265Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    nalu.pNaluData = naluBuffer;
+    nalu.naluDataLength = sizeof( naluBuffer );
+
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_MALFORMED_PACKET, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265Depacketizer FU when payloadLength exceeds naluDataLength.
+ */
+void test_H265_Depacketizer_FU_PayloadExceedsNaluLength( void )
+{
+    H265Result_t result;
+    H265DepacketizerContext_t ctx = { 0 };
+    H265Packet_t packetsArray[ 1 ];
+    H265Nalu_t nalu;
+    uint8_t naluBuffer[ 3 ];
+    uint8_t packetData[] = { 0x62, 0x01, 0x80, 0xAA, 0xBB, 0xCC, 0xDD };
+
+    result = H265Depacketizer_Init( &( ctx ), packetsArray, 1 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    H265Packet_t pkt = { packetData, sizeof( packetData ) };
+    result = H265Depacketizer_AddPacket( &( ctx ), &( pkt ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    nalu.pNaluData = naluBuffer;
+    nalu.naluDataLength = 3;
+
+    result = H265Depacketizer_GetNalu( &( ctx ), &( nalu ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test H265Packetizer aggregation when second NALU size exceeds packet buffer.
+ */
+void test_H265_Packetizer_Aggregation_SecondNaluExceedsBuffer( void )
+{
+    H265Result_t result;
+    H265PacketizerContext_t ctx;
+    H265Nalu_t naluArray[ 3 ];
+    uint8_t naluData1[] = { 0x40, 0x01, 0xAA, 0xBB };
+    uint8_t naluData2[] = { 0x42, 0x02, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 };
+    H265Nalu_t nalu1 = { naluData1, sizeof( naluData1 ) };
+    H265Nalu_t nalu2 = { naluData2, sizeof( naluData2 ) };
+    H265Packet_t packet = { packetBuffer, 12 };
+
+    result = H265Packetizer_Init( &( ctx ), naluArray, 3 );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu1 ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_AddNalu( &( ctx ), &( nalu2 ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+
+    result = H265Packetizer_GetPacket( &( ctx ), &( packet ) );
+    TEST_ASSERT_EQUAL( H265_RESULT_OK, result );
+}
+
+/*-----------------------------------------------------------*/

--- a/test/unit-test/opus/opus_utest.c
+++ b/test/unit-test/opus/opus_utest.c
@@ -353,6 +353,15 @@ void test_Opus_Depacketizer_AddPacket_BadParams( void )
 
     TEST_ASSERT_EQUAL( result,
                        OPUS_RESULT_BAD_PARAM );
+
+    pkt.pPacketData = NULL;
+    pkt.packetDataLength = 10;
+
+    result = OpusDepacketizer_AddPacket( &( ctx ),
+                                         &( pkt ) );
+
+    TEST_ASSERT_EQUAL( result,
+                       OPUS_RESULT_BAD_PARAM );
 }
 
 /*-----------------------------------------------------------*/
@@ -517,6 +526,39 @@ void test_Opus_Depacketizer_GetFrame_NoPackets( void )
 
     TEST_ASSERT_EQUAL( OPUS_RESULT_NO_MORE_PACKETS,
                        result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test OpusDepacketizer_GetFrame with null packet data in stored packets
+ */
+void test_Opus_Depacketizer_GetFrame_NullStoredPacketData( void )
+{
+    OpusResult_t result;
+    OpusDepacketizerContext_t ctx = { 0 };
+    OpusPacket_t packetsArray[ MAX_PACKET_IN_A_FRAME ];
+    OpusFrame_t frame;
+    uint8_t packetData[] = { 0x01, 0x02, 0x03 };
+
+    result = OpusDepacketizer_Init( &( ctx ),
+                                    &( packetsArray[ 0 ] ),
+                                    MAX_PACKET_IN_A_FRAME );
+    TEST_ASSERT_EQUAL( OPUS_RESULT_OK, result );
+
+    /* Manually corrupt stored packet data to simulate memory corruption */
+    packetsArray[ 0 ].pPacketData = packetData;
+    packetsArray[ 0 ].packetDataLength = sizeof( packetData );
+    ctx.packetCount = 1;
+
+    /* Corrupt the stored packet data pointer */
+    packetsArray[ 0 ].pPacketData = NULL;
+
+    frame.pFrameData = &( frameBuffer[ 0 ] );
+    frame.frameDataLength = MAX_FRAME_LENGTH;
+
+    result = OpusDepacketizer_GetFrame( &( ctx ), &( frame ) );
+    TEST_ASSERT_EQUAL( OPUS_RESULT_OUT_OF_MEMORY, result );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix integer overflow of payloadLength and curPacketLength in depacketizer 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
